### PR TITLE
feat(runtime): add idle_cached lifecycle + Claude session resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Agent definitions live in a single JSON file:
 
 Each agent entry has:
 - `name` — unique identifier used on the message bus.
-- `lifecycle` — `24/7` (continuous respawn loop), `on-demand` (idle until triggered), or `idle_cached` (idle until triggered, but the prior Claude `session_id` is preserved across triggers via `claude --resume` so context survives idle periods).
+- `lifecycle` — `24/7` (continuous respawn loop), `on-demand` (idle until triggered), or `idle_cached` (idle until triggered, but the prior Claude `session_id` is preserved across triggers via `claude --resume` so context survives idle periods). **`idle_cached` is Claude-only**: pairing it with `runtime: codex` (or `WANMAN_RUNTIME=codex`) is rejected at startup since Codex has no equivalent resume mechanism in this runtime.
 - `model` — usually an abstract tier (`high` or `standard`); the runtime adapter maps it to Claude or Codex defaults, with environment overrides available.
 - `systemPrompt` — baked-in persona/mission; agents also auto-discover shared skill files at `~/.claude/skills/`.
 - Optional `cron`, `events`, and `tools` fields — see the architecture doc for the full schema.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Agent definitions live in a single JSON file:
 
 Each agent entry has:
 - `name` — unique identifier used on the message bus.
-- `lifecycle` — `24/7` (continuous respawn loop) or `on-demand` (idle until triggered).
+- `lifecycle` — `24/7` (continuous respawn loop), `on-demand` (idle until triggered), or `idle_cached` (idle until triggered, but the prior Claude `session_id` is preserved across triggers via `claude --resume` so context survives idle periods).
 - `model` — usually an abstract tier (`high` or `standard`); the runtime adapter maps it to Claude or Codex defaults, with environment overrides available.
 - `systemPrompt` — baked-in persona/mission; agents also auto-discover shared skill files at `~/.claude/skills/`.
 - Optional `cron`, `events`, and `tools` fields — see the architecture doc for the full schema.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ start()
 - A steer-priority message or a cron tick triggers a single execution, after which the agent falls back to `idle`.
 - Each spawn is stateless: the next trigger gets a fresh CLI session.
 
-### 2.3 `idle_cached` — idle, but with resumed context
+### 2.3 `idle_cached` — idle, but with resumed context (Claude-only)
 
 ```
 start()
@@ -75,19 +75,20 @@ start()
 
 trigger() / handleSteer()
   +- relay.recv()
-  +- spawnClaudeOrCodex({ resumeSessionId: lastSessionId })   # claude --resume <id>
-  +- onSessionId(id => lastSessionId = id)                    # captured from system/init
+  +- spawnClaudeCode({ resumeSessionId: lastSessionId })   # claude --resume <id>
+  +- onSessionId(id => lastSessionId = id)                 # captured from system/init
   +- wait()
-  +- if resumeMissed():                                       # stale session
+  +- if resumeMissed():                                    # stale session
        lastSessionId = null
-       respawn without --resume                               # cold-start fallback
-  +- state = 'idle' again        (but lastSessionId is preserved)
+       respawn without --resume                            # cold-start fallback
+  +- state = 'idle' again      (but lastSessionId is preserved)
 ```
 
 - Same idle CPU profile as `on-demand`, but conversation context survives idle periods because the next spawn passes the captured Claude `session_id` as `--resume <id>`.
 - The first trigger always cold-starts (no captured session yet).
 - If the local Claude CLI has dropped the session id (rotated, manually deleted, etc.), the runtime detects the failure via stderr + exit code, clears the cached id, and re-spawns once without `--resume`. No agent gets stranded.
 - Useful for stateful long-running roles where keeping a process alive forever would be wasteful but losing context every trigger is also wrong (e.g. a "support" agent that should remember the customer between messages).
+- **Claude-only.** The resume mechanism depends on `claude --resume` and Claude Code's `system/init` session id; Codex has no equivalent in this runtime today. Pairing `idle_cached` with `runtime: codex` (or letting `WANMAN_RUNTIME=codex` flip the effective runtime) is rejected at supervisor startup so the misconfig surfaces loudly instead of silently degrading to `on-demand` semantics.
 
 ### 2.4 Agent states
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,8 +64,32 @@ start()
 
 - Initial state is `idle`; no CPU is spent until something pokes it.
 - A steer-priority message or a cron tick triggers a single execution, after which the agent falls back to `idle`.
+- Each spawn is stateless: the next trigger gets a fresh CLI session.
 
-### 2.3 Agent states
+### 2.3 `idle_cached` — idle, but with resumed context
+
+```
+start()
+  +-> state = 'idle'           (no CLI subprocess running)
+  +-> lastSessionId = null
+
+trigger() / handleSteer()
+  +- relay.recv()
+  +- spawnClaudeOrCodex({ resumeSessionId: lastSessionId })   # claude --resume <id>
+  +- onSessionId(id => lastSessionId = id)                    # captured from system/init
+  +- wait()
+  +- if resumeMissed():                                       # stale session
+       lastSessionId = null
+       respawn without --resume                               # cold-start fallback
+  +- state = 'idle' again        (but lastSessionId is preserved)
+```
+
+- Same idle CPU profile as `on-demand`, but conversation context survives idle periods because the next spawn passes the captured Claude `session_id` as `--resume <id>`.
+- The first trigger always cold-starts (no captured session yet).
+- If the local Claude CLI has dropped the session id (rotated, manually deleted, etc.), the runtime detects the failure via stderr + exit code, clears the cached id, and re-spawns once without `--resume`. No agent gets stranded.
+- Useful for stateful long-running roles where keeping a process alive forever would be wasteful but losing context every trigger is also wrong (e.g. a "support" agent that should remember the customer between messages).
+
+### 2.4 Agent states
 
 | State | Meaning |
 |-------|---------|

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,9 +8,13 @@
  * - `idle_cached` — idle until triggered (like `on-demand`), but the runtime
  *                   remembers the previous Claude `session_id` and resumes
  *                   it on the next trigger via `claude --resume`. Combines
- *                   "no CPU when idle" with "preserved conversation context",
- *                   which is essential for stateful long-running roles where
- *                   keeping the process alive forever would be wasteful.
+ *                   "no CPU when idle" with "preserved conversation context".
+ *                   **Claude-only.** The resume mechanism depends on Claude
+ *                   Code's `system/init` session id and `--resume` flag;
+ *                   Codex has no equivalent in this runtime today, so the
+ *                   supervisor rejects `idle_cached` paired with a non-Claude
+ *                   runtime at startup rather than letting it silently
+ *                   degrade to `on-demand` semantics.
  */
 export type AgentLifecycle = '24/7' | 'on-demand' | 'idle_cached';
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,18 @@
-/** Agent lifecycle mode */
-export type AgentLifecycle = '24/7' | 'on-demand';
+/**
+ * Agent lifecycle mode.
+ *
+ * - `24/7`        — continuous respawn loop. The agent boots a fresh CLI
+ *                   subprocess every iteration. Use for always-on roles.
+ * - `on-demand`   — idle until triggered (cron / steer / message). Each
+ *                   trigger starts a fresh, stateless run.
+ * - `idle_cached` — idle until triggered (like `on-demand`), but the runtime
+ *                   remembers the previous Claude `session_id` and resumes
+ *                   it on the next trigger via `claude --resume`. Combines
+ *                   "no CPU when idle" with "preserved conversation context",
+ *                   which is essential for stateful long-running roles where
+ *                   keeping the process alive forever would be wasteful.
+ */
+export type AgentLifecycle = '24/7' | 'on-demand' | 'idle_cached';
 
 /** Agent runtime backend */
 export type AgentRuntime = 'claude' | 'codex';

--- a/packages/runtime/src/__tests__/agent-process.test.ts
+++ b/packages/runtime/src/__tests__/agent-process.test.ts
@@ -161,6 +161,48 @@ describe('AgentProcess', () => {
       expect(agent.state).toBe('idle')
     })
 
+    it('rejects idle_cached + declared codex runtime at construction', () => {
+      expect(() => new AgentProcess(
+        makeDef({ name: 'support', lifecycle: 'idle_cached', runtime: 'codex' }),
+        relay,
+        '/tmp/work',
+      )).toThrow(/idle_cached only works with the Claude runtime/)
+    })
+
+    it('rejects idle_cached when WANMAN_RUNTIME forces effective runtime to codex', () => {
+      const original = process.env['WANMAN_RUNTIME']
+      process.env['WANMAN_RUNTIME'] = 'codex'
+      try {
+        expect(() => new AgentProcess(
+          makeDef({ name: 'support', lifecycle: 'idle_cached' }),
+          relay,
+          '/tmp/work',
+        )).toThrow(/forced by WANMAN_RUNTIME=codex/)
+      } finally {
+        if (original === undefined) delete process.env['WANMAN_RUNTIME']
+        else process.env['WANMAN_RUNTIME'] = original
+      }
+    })
+
+    it('accepts idle_cached + claude runtime', () => {
+      const agent = new AgentProcess(
+        makeDef({ name: 'support', lifecycle: 'idle_cached', runtime: 'claude' }),
+        relay,
+        '/tmp/work',
+      )
+      expect(agent.state).toBe('idle')
+      expect(agent.definition.lifecycle).toBe('idle_cached')
+    })
+
+    it('accepts idle_cached with default runtime (claude)', () => {
+      const agent = new AgentProcess(
+        makeDef({ name: 'support', lifecycle: 'idle_cached' }),
+        relay,
+        '/tmp/work',
+      )
+      expect(agent.state).toBe('idle')
+    })
+
     it('should store definition', () => {
       const def = makeDef({ name: 'my-agent' })
       const agent = new AgentProcess(def, relay, '/tmp/work')

--- a/packages/runtime/src/__tests__/agent-process.test.ts
+++ b/packages/runtime/src/__tests__/agent-process.test.ts
@@ -21,7 +21,20 @@ function deferred<T>() {
 // Per-call wait deferreds
 let waitDeferreds: Array<ReturnType<typeof deferred<number>>>
 let eventHandlers: Array<((event: Record<string, unknown>) => void) | undefined>
+/** Per-call session-id reporter. Tests call this to simulate Claude emitting
+ *  a system/init session id, which AgentProcess captures for idle_cached. */
+let sessionIdReporters: Array<(sessionId: string) => void>
+/** Per-call exit handler — AgentProcess registers one to read resumeMissed
+ *  after the process exits. The mock spawn invokes it on wait()-resolve. */
+let exitReporters: Array<(code: number) => void>
+/** Per-call resumeMissed flag — tests flip this via `setSpawnResumeMissed`
+ *  to simulate Claude refusing the requested --resume id. */
+let resumeMissedFlags: boolean[]
 let spawnCallCount: number
+
+function setSpawnResumeMissed(idx: number, missed: boolean) {
+  resumeMissedFlags[idx] = missed
+}
 
 const mockKill = vi.fn()
 const codexStartRunMock = vi.hoisted(() => vi.fn())
@@ -33,15 +46,30 @@ vi.mock('../claude-code.js', () => ({
       waitDeferreds[idx] = deferred<number>()
     }
     const handlers: { event?: (event: Record<string, unknown>) => void } = {}
+    const sessionIdHandlers: Array<(id: string) => void> = []
+    const exitHandlers: Array<(code: number) => void> = []
     eventHandlers[idx] = (event) => handlers.event?.(event)
+    sessionIdReporters[idx] = (id) => {
+      for (const h of sessionIdHandlers) h(id)
+    }
+    exitReporters[idx] = (code) => {
+      for (const h of exitHandlers) h(code)
+    }
     return {
       proc: { pid: 12345, stdin: { end: vi.fn() } },
-      wait: vi.fn(() => waitDeferreds[idx]!.promise),
+      wait: vi.fn(async () => {
+        const code = await waitDeferreds[idx]!.promise
+        // Mirror real adapter behaviour: onExit fires after wait resolves.
+        for (const h of exitHandlers) h(code)
+        return code
+      }),
       kill: mockKill,
       sendMessage: vi.fn(),
       onEvent: vi.fn((handler) => { handlers.event = handler }),
       onResult: vi.fn(),
-      onExit: vi.fn(),
+      onSessionId: vi.fn((handler) => { sessionIdHandlers.push(handler) }),
+      onExit: vi.fn((handler) => { exitHandlers.push(handler) }),
+      resumeMissed: vi.fn(() => resumeMissedFlags[idx] ?? false),
     }
   }),
 }))
@@ -106,6 +134,9 @@ describe('AgentProcess', () => {
     codexStartRunMock.mockClear()
     waitDeferreds = []
     eventHandlers = []
+    sessionIdReporters = []
+    exitReporters = []
+    resumeMissedFlags = []
     spawnCallCount = 0
     relay = makeRelay()
   })
@@ -140,6 +171,12 @@ describe('AgentProcess', () => {
   describe('start — on-demand', () => {
     it('should stay idle for on-demand agents', async () => {
       const agent = new AgentProcess(makeDef({ lifecycle: 'on-demand' }), relay, '/tmp')
+      await agent.start()
+      expect(agent.state).toBe('idle')
+    })
+
+    it('should stay idle for idle_cached agents (no respawn loop)', async () => {
+      const agent = new AgentProcess(makeDef({ lifecycle: 'idle_cached' }), relay, '/tmp')
       await agent.start()
       expect(agent.state).toBe('idle')
     })
@@ -366,6 +403,132 @@ describe('AgentProcess', () => {
       // No new messages arrived during execution — should NOT re-trigger
       expect(vi.mocked(spawnClaudeCode).mock.calls.length).toBe(1)
       expect(agent.state).toBe('idle')
+    })
+
+    it('on-demand never passes resumeSessionId, even after a session id is observed', async () => {
+      const { spawnClaudeCode } = await import('../claude-code.js')
+      waitDeferreds[0] = deferred<number>()
+      waitDeferreds[1] = deferred<number>()
+
+      const agent = new AgentProcess(makeDef({ lifecycle: 'on-demand' }), relay, '/tmp')
+
+      // First trigger: relay enqueues msg1, mock fires onSessionId mid-run.
+      relay.send('alice', 'test-agent', 'message', 'msg1', 'normal')
+      const t1 = agent.trigger()
+      await new Promise((r) => setTimeout(r, 5))
+      sessionIdReporters[0]!('session-from-claude-1')
+      waitDeferreds[0].resolve(0)
+      await t1
+
+      // Second trigger should still spawn fresh — on-demand discards the id.
+      relay.send('alice', 'test-agent', 'message', 'msg2', 'normal')
+      const t2 = agent.trigger()
+      await new Promise((r) => setTimeout(r, 5))
+      waitDeferreds[1].resolve(0)
+      await t2
+
+      const calls = vi.mocked(spawnClaudeCode).mock.calls
+      expect(calls.length).toBe(2)
+      expect(calls[0]![0]).not.toHaveProperty('resumeSessionId')
+      expect(calls[1]![0]).not.toHaveProperty('resumeSessionId')
+    })
+  })
+
+  describe('trigger — idle_cached', () => {
+    it('skips resumeSessionId on the very first trigger (no session captured yet)', async () => {
+      const { spawnClaudeCode } = await import('../claude-code.js')
+      waitDeferreds[0] = deferred<number>()
+      waitDeferreds[0].resolve(0)
+
+      const agent = new AgentProcess(makeDef({ lifecycle: 'idle_cached' }), relay, '/tmp')
+      relay.send('alice', 'test-agent', 'message', 'first message', 'normal')
+
+      await agent.trigger()
+
+      const calls = vi.mocked(spawnClaudeCode).mock.calls
+      expect(calls.length).toBe(1)
+      expect(calls[0]![0].resumeSessionId).toBeUndefined()
+    })
+
+    it('passes the previously-captured session id as resumeSessionId on the next trigger', async () => {
+      const { spawnClaudeCode } = await import('../claude-code.js')
+      waitDeferreds[0] = deferred<number>()
+      waitDeferreds[1] = deferred<number>()
+
+      const agent = new AgentProcess(makeDef({ lifecycle: 'idle_cached' }), relay, '/tmp')
+
+      relay.send('alice', 'test-agent', 'message', 'msg1', 'normal')
+      const t1 = agent.trigger()
+      await new Promise((r) => setTimeout(r, 5))
+      sessionIdReporters[0]!('captured-session-xyz')
+      waitDeferreds[0].resolve(0)
+      await t1
+
+      relay.send('alice', 'test-agent', 'message', 'msg2', 'normal')
+      const t2 = agent.trigger()
+      await new Promise((r) => setTimeout(r, 5))
+      waitDeferreds[1].resolve(0)
+      await t2
+
+      const calls = vi.mocked(spawnClaudeCode).mock.calls
+      expect(calls.length).toBe(2)
+      expect(calls[0]![0].resumeSessionId).toBeUndefined()
+      expect(calls[1]![0].resumeSessionId).toBe('captured-session-xyz')
+    })
+
+    it('falls back to a cold-start retry without resume when the prior session is missing', async () => {
+      const { spawnClaudeCode } = await import('../claude-code.js')
+      waitDeferreds[0] = deferred<number>()
+      waitDeferreds[1] = deferred<number>()
+      waitDeferreds[2] = deferred<number>()
+
+      const agent = new AgentProcess(makeDef({ lifecycle: 'idle_cached' }), relay, '/tmp')
+
+      // Run 1: capture a session id.
+      relay.send('alice', 'test-agent', 'message', 'msg1', 'normal')
+      const t1 = agent.trigger()
+      await new Promise((r) => setTimeout(r, 5))
+      sessionIdReporters[0]!('about-to-go-stale')
+      waitDeferreds[0].resolve(0)
+      await t1
+
+      // Run 2: simulate Claude rejecting --resume on the next spawn. The
+      // mock's resumeMissed flag is read inside onExit, which AgentProcess
+      // checks after wait() resolves.
+      setSpawnResumeMissed(1, true)
+      relay.send('alice', 'test-agent', 'message', 'msg2', 'normal')
+      const t2 = agent.trigger()
+      await new Promise((r) => setTimeout(r, 5))
+      waitDeferreds[1].resolve(0)
+      // Wait for AgentProcess to observe resumeMissed and fire the cold-start.
+      await new Promise((r) => setTimeout(r, 10))
+      waitDeferreds[2].resolve(0)
+      await t2
+
+      const calls = vi.mocked(spawnClaudeCode).mock.calls
+      expect(calls.length).toBe(3)
+      // Spawn 1: cold start (no session yet)
+      expect(calls[0]![0].resumeSessionId).toBeUndefined()
+      // Spawn 2: tried to resume the captured id...
+      expect(calls[1]![0].resumeSessionId).toBe('about-to-go-stale')
+      // Spawn 3: cold-start retry after the resume miss
+      expect(calls[2]![0].resumeSessionId).toBeUndefined()
+    })
+
+    it('handleSteer triggers idle_cached agents the same way it triggers on-demand', async () => {
+      waitDeferreds[0] = deferred<number>()
+      waitDeferreds[0].resolve(0)
+
+      const agent = new AgentProcess(makeDef({ lifecycle: 'idle_cached' }), relay, '/tmp')
+      await agent.start()
+      expect(agent.state).toBe('idle')
+
+      relay.send('alice', 'test-agent', 'message', 'urgent', 'steer')
+      agent.handleSteer()
+
+      // Let the async trigger run to completion.
+      await new Promise((r) => setTimeout(r, 10))
+      expect(spawnCallCount).toBeGreaterThanOrEqual(1)
     })
 
     it('merges per-run environment from envProvider before spawn', async () => {

--- a/packages/runtime/src/__tests__/claude-code.test.ts
+++ b/packages/runtime/src/__tests__/claude-code.test.ts
@@ -435,6 +435,81 @@ describe('spawnClaudeCode', () => {
     expect(handle.resumeMissed()).toBe(false)
   })
 
+  it('should set resumeMissed for Claude Code 2.1.119 stderr wording', async () => {
+    // Regression: this exact wording was reported by chekusu/wanman#2 reviewer
+    // testing against Claude Code 2.1.119. The earlier regex required
+    // "session" specifically and missed the "conversation" wording.
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+      resumeSessionId: 'abc-stale',
+    })
+
+    latestProc.stderr.push(Buffer.from('No conversation found with session ID: abc-stale\n'))
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(handle.resumeMissed()).toBe(true)
+  })
+
+  it('should set resumeMissed when the failure surfaces on the structured result event', async () => {
+    // Claude Code 2.1.119+ also delivers the failure as a JSONL `result`
+    // event with is_error=true and the message in either result/errors.
+    // Detecting it on the JSONL channel is more stable than stderr because
+    // the JSONL schema is versioned.
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+      resumeSessionId: 'abc-stale',
+    })
+
+    latestProc.stdout.push(JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'No conversation found with session ID: abc-stale',
+    }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(handle.resumeMissed()).toBe(true)
+  })
+
+  it('should set resumeMissed when result event reports the failure inside errors[]', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+      resumeSessionId: 'abc-stale',
+    })
+
+    latestProc.stdout.push(JSON.stringify({
+      type: 'result',
+      is_error: true,
+      errors: ['No conversation found with session ID: abc-stale'],
+    }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(handle.resumeMissed()).toBe(true)
+  })
+
+  it('should NOT set resumeMissed for unrelated is_error result events', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+      resumeSessionId: 'abc-stale',
+    })
+
+    latestProc.stdout.push(JSON.stringify({
+      type: 'result',
+      is_error: true,
+      result: 'Max turns exceeded',
+    }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(handle.resumeMissed()).toBe(false)
+  })
+
   it('should handle result with non-string result field', async () => {
     const handle = spawnClaudeCode({
       model: 'haiku',

--- a/packages/runtime/src/__tests__/claude-code.test.ts
+++ b/packages/runtime/src/__tests__/claude-code.test.ts
@@ -58,6 +58,7 @@ vi.mock('../logger.js', () => ({
 
 // Import after mocks are set up
 const { spawnClaudeCode } = await import('../claude-code.js')
+const { spawn: spawnMock } = await import('child_process')
 
 describe('spawnClaudeCode', () => {
   beforeEach(() => {
@@ -307,6 +308,131 @@ describe('spawnClaudeCode', () => {
     // Second kill should be a no-op since proc.killed is now true
     handle.kill()
     expect(latestProc.kill).not.toHaveBeenCalled()
+  })
+
+  it('should not pass --resume by default', () => {
+    spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+
+    const calls = (spawnMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const args = calls[calls.length - 1]![1] as string[]
+    expect(args).not.toContain('--resume')
+  })
+
+  it('should pass --resume <id> when resumeSessionId is set', () => {
+    spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+      resumeSessionId: 'session-abc-123',
+    })
+
+    const calls = (spawnMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const args = calls[calls.length - 1]![1] as string[]
+    const idx = args.indexOf('--resume')
+    expect(idx).toBeGreaterThanOrEqual(0)
+    expect(args[idx + 1]).toBe('session-abc-123')
+  })
+
+  it('should fire onSessionId for system/init events', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+
+    const observed: string[] = []
+    handle.onSessionId((id) => observed.push(id))
+
+    latestProc.stdout.push(JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'session-from-init',
+    }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(observed).toEqual(['session-from-init'])
+  })
+
+  it('should not double-fire onSessionId when the same id is reported twice', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+
+    const observed: string[] = []
+    handle.onSessionId((id) => observed.push(id))
+
+    const event = JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'stable-id',
+    }) + '\n'
+    latestProc.stdout.push(event)
+    latestProc.stdout.push(event)
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(observed).toEqual(['stable-id'])
+  })
+
+  it('should replay the latest session id to handlers registered late', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+
+    latestProc.stdout.push(JSON.stringify({
+      type: 'system',
+      subtype: 'init',
+      session_id: 'late-handler-id',
+    }) + '\n')
+
+    await new Promise((r) => setTimeout(r, 50))
+
+    const observed: string[] = []
+    handle.onSessionId((id) => observed.push(id))
+    expect(observed).toEqual(['late-handler-id'])
+  })
+
+  it('should report resumeMissed false by default', () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+    expect(handle.resumeMissed()).toBe(false)
+  })
+
+  it('should set resumeMissed when stderr reports the resumed session is missing', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+      resumeSessionId: 'stale-session',
+    })
+
+    latestProc.stderr.push(Buffer.from('Error: No session found with id stale-session\n'))
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(handle.resumeMissed()).toBe(true)
+  })
+
+  it('should NOT set resumeMissed when no resumeSessionId was passed', async () => {
+    const handle = spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+
+    latestProc.stderr.push(Buffer.from('Error: No session found\n'))
+
+    await new Promise((r) => setTimeout(r, 50))
+    expect(handle.resumeMissed()).toBe(false)
   })
 
   it('should handle result with non-string result field', async () => {

--- a/packages/runtime/src/agent-adapter.ts
+++ b/packages/runtime/src/agent-adapter.ts
@@ -14,7 +14,19 @@ export interface AgentRunHandle {
   wait(): Promise<number>;
   onEvent(handler: (event: AgentRunEvent) => void): void;
   onResult(handler: (result: string, isError: boolean) => void): void;
+  /**
+   * Adapter-reported session id (e.g. Claude `system/init` event). May fire
+   * zero, one, or multiple times depending on the adapter. Adapters that
+   * cannot report a session id may simply never invoke the handler.
+   */
+  onSessionId?(handler: (sessionId: string) => void): void;
   onExit(handler: (code: number) => void): void;
+  /**
+   * True when the adapter attempted to resume a session id but the runtime
+   * could not find it locally. Used by callers to fall back to a cold start.
+   * Adapters without resume support always return false.
+   */
+  resumeMissed?(): boolean;
 }
 
 export interface AgentRunOptions {
@@ -32,6 +44,13 @@ export interface AgentRunOptions {
   cwd: string;
   initialMessage?: string;
   sessionId?: string;
+  /**
+   * Resume a previously-captured session. The Claude adapter passes this as
+   * `--resume <id>`. Other adapters may ignore it. When the session cannot
+   * be found locally, `AgentRunHandle.resumeMissed()` returns true so the
+   * caller can retry without resume.
+   */
+  resumeSessionId?: string;
   env?: Record<string, string>;
   runAsUser?: string;
 }

--- a/packages/runtime/src/agent-process.ts
+++ b/packages/runtime/src/agent-process.ts
@@ -3,6 +3,10 @@
  *
  * - 24/7 agents: run in a loop, respawning when Claude Code exits
  * - on-demand agents: spawned when a message arrives, exit when done
+ * - idle_cached agents: like on-demand, but the runtime persists the
+ *   session id across triggers so the next spawn resumes prior context
+ *   via `claude --resume`. Combines "no CPU when idle" with "preserved
+ *   conversation context" for stateful agents that should not run forever.
  * - steer: when a steer message arrives, kill the current process and
  *   respawn with the steer message prepended (safest approach per design doc)
  */
@@ -115,6 +119,19 @@ export class AgentProcess {
   private envProvider?: EnvironmentProvider;
   /** Latest runtime-reported token usage snapshot for the active run. */
   private currentUsage: TokenUsageSnapshot = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  /**
+   * Most recent session id reported by the underlying CLI (e.g. Claude's
+   * `system/init` event). For `idle_cached` agents this is passed back as
+   * `resumeSessionId` on the next spawn so the agent retains conversation
+   * context across idle periods. Cleared on a stale-session fallback.
+   */
+  private lastSessionId: string | null = null;
+  /**
+   * Set by `registerSessionIdCapture` when the most recent spawn passed a
+   * resume id but the adapter reported the session was unavailable. Read
+   * (and reset) by `trigger()` to drive the cold-start retry path.
+   */
+  private lastSpawnResumeMissed = false;
 
   constructor(
     definition: AgentDefinition,
@@ -142,14 +159,27 @@ export class AgentProcess {
     this.envProvider = envProvider;
   }
 
-  /** Start the agent. For 24/7 agents, enters a run loop. For on-demand, waits. */
+  /**
+   * Start the agent. Behaviour depends on the configured lifecycle:
+   * - `24/7`: enter a respawn loop. Each loop iteration spawns a fresh CLI
+   *   subprocess (with the agent's system prompt + a fresh session by
+   *   default).
+   * - `on-demand`: stay idle. Triggered explicitly by `trigger()` or
+   *   `handleSteer()`; each run is stateless.
+   * - `idle_cached`: stay idle like `on-demand`. Differs only in that
+   *   `lastSessionId` is preserved across triggers, so the next run resumes
+   *   the prior Claude session via `--resume`.
+   */
   async start(): Promise<void> {
     if (this.definition.lifecycle === '24/7') {
       this.runLoop();
     } else {
-      // on-demand: stay idle, will be triggered by handleSteer or trigger()
+      // on-demand / idle_cached: stay idle, will be triggered by handleSteer or trigger()
       this._state = 'idle';
-      log.info('on-demand agent ready', { agent: this.definition.name });
+      log.info('idle agent ready', {
+        agent: this.definition.name,
+        lifecycle: this.definition.lifecycle,
+      });
     }
   }
 
@@ -240,6 +270,7 @@ export class AgentProcess {
 
         // Log tool calls so we can see what each agent is doing
         this.registerEventLogger(this.currentProcess);
+        this.registerSessionIdCapture(this.currentProcess);
 
         // End stdin after initial message (single-shot per spawn)
         this.currentProcess.proc.stdin?.end();
@@ -311,13 +342,21 @@ export class AgentProcess {
       // The run loop will pick up the steer message on next iteration
     }
 
-    // For on-demand agents, trigger a new run
-    if (this.definition.lifecycle === 'on-demand' && this._state === 'idle') {
+    // For on-demand / idle_cached agents, trigger a new run
+    if (
+      (this.definition.lifecycle === 'on-demand' || this.definition.lifecycle === 'idle_cached')
+      && this._state === 'idle'
+    ) {
       this.trigger();
     }
   }
 
-  /** Trigger an on-demand agent — spawn once, then return to idle. */
+  /**
+   * Trigger an on-demand or idle_cached agent — spawn once, then return to
+   * idle. For `idle_cached`, the previous session id is passed as
+   * `resumeSessionId`; if Claude reports the session is unavailable, the
+   * spawn is retried once without resume to force a cold-start.
+   */
   async trigger(): Promise<void> {
     if (this._state === 'running') {
       log.warn('agent already running, ignoring trigger', { agent: this.definition.name });
@@ -357,52 +396,53 @@ export class AgentProcess {
     const runEnv = { ...this.extraEnv, ...dynamicEnv };
     const reasoningEffort = resolveCodexReasoningEffort(runEnv, runtime);
     const fast = resolveCodexFast(runEnv, runtime);
-    log.info('triggering on-demand agent', {
+    const resumeSessionId = this.definition.lifecycle === 'idle_cached'
+      ? this.lastSessionId ?? undefined
+      : undefined;
+    log.info('triggering agent', {
       agent: this.definition.name,
+      lifecycle: this.definition.lifecycle,
       messageCount: pending.length,
       runtime,
       model,
+      ...(resumeSessionId ? { resumeSessionId } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),
       ...(fast ? { fast: true } : {}),
     });
 
-    this.currentProcess = createAgentAdapter(runtime).startRun({
-      runtime,
-      model,
-      reasoningEffort,
-      fast,
-      systemPrompt: this.definition.systemPrompt,
-      cwd: this.workDir,
-      initialMessage: prompt,
-      env: runEnv,
-      runAsUser: process.env['WANMAN_AGENT_USER'],
+    let exitCode = await this.runOneShot({
+      runtime, model, reasoningEffort, fast, prompt, runEnv, resumeSessionId,
     });
 
-    // Log tool calls so we can see what each agent is doing
-    this.registerEventLogger(this.currentProcess);
-
-    // End stdin — single-shot execution
-    this.currentProcess.proc.stdin?.end();
-
-    // Time budget for on-demand agents
-    let budgetTimer: ReturnType<typeof setTimeout> | null = null;
-    if (this.timeBudgetMs && this.currentProcess) {
-      const proc = this.currentProcess;
-      budgetTimer = setTimeout(() => {
-        log.warn('time budget exceeded, killing on-demand agent', {
-          agent: this.definition.name, budgetMs: this.timeBudgetMs,
-        });
-        proc.kill();
-      }, this.timeBudgetMs);
+    // idle_cached fallback: if Claude reported the resumed session is missing,
+    // retry once without resume so we don't strand the agent.
+    if (
+      this.definition.lifecycle === 'idle_cached'
+      && resumeSessionId
+      && this.lastSpawnResumeMissed
+    ) {
+      log.warn('resume session missing, falling back to cold start', {
+        agent: this.definition.name,
+        staleSessionId: resumeSessionId,
+      });
+      this.lastSessionId = null;
+      this.lastSpawnResumeMissed = false;
+      exitCode = await this.runOneShot({
+        runtime, model, reasoningEffort, fast, prompt, runEnv,
+      });
     }
 
-    const exitCode = await this.currentProcess.wait();
-    if (budgetTimer) clearTimeout(budgetTimer);
     const runDuration = Date.now() - runStartTime;
-    this.currentProcess = null;
     this.setIdleIfActive();
     await this.credentialManager?.syncFromFile();
-    log.info('on-demand agent finished', { agent: this.definition.name, exitCode });
+    log.info('agent finished', {
+      agent: this.definition.name,
+      lifecycle: this.definition.lifecycle,
+      exitCode,
+      ...(this.lastSessionId && this.definition.lifecycle === 'idle_cached'
+        ? { cachedSessionId: this.lastSessionId }
+        : {}),
+    });
 
     // Fire run complete callback for feedback tracking
     try {
@@ -503,6 +543,77 @@ export class AgentProcess {
         });
       }
     });
+  }
+
+  /**
+   * Subscribe to session-id and resume-miss signals from the adapter so
+   * `idle_cached` agents can persist context across triggers. Adapters
+   * without resume support simply never invoke these hooks, leaving
+   * `lastSessionId` unchanged.
+   */
+  private registerSessionIdCapture(proc: AgentRunHandle): void {
+    proc.onSessionId?.((sessionId) => {
+      if (sessionId && this.lastSessionId !== sessionId) {
+        this.lastSessionId = sessionId;
+        log.debug?.('captured session id', {
+          agent: this.definition.name,
+          sessionId,
+        });
+      }
+    });
+    proc.onExit((_code) => {
+      if (proc.resumeMissed?.()) this.lastSpawnResumeMissed = true;
+    });
+  }
+
+  /**
+   * Spawn one CLI subprocess, wait for it to exit, and clean up. Shared
+   * between `trigger()` (single-shot) and the `idle_cached` cold-start
+   * retry path so they apply the same time-budget and lifecycle rules.
+   */
+  private async runOneShot(opts: {
+    runtime: 'claude' | 'codex';
+    model: string;
+    reasoningEffort: 'low' | 'medium' | 'high' | 'xhigh' | undefined;
+    fast: boolean;
+    prompt: string;
+    runEnv: Record<string, string>;
+    resumeSessionId?: string;
+  }): Promise<number> {
+    this.currentProcess = createAgentAdapter(opts.runtime).startRun({
+      runtime: opts.runtime,
+      model: opts.model,
+      reasoningEffort: opts.reasoningEffort,
+      fast: opts.fast,
+      systemPrompt: this.definition.systemPrompt,
+      cwd: this.workDir,
+      initialMessage: opts.prompt,
+      ...(opts.resumeSessionId ? { resumeSessionId: opts.resumeSessionId } : {}),
+      env: opts.runEnv,
+      runAsUser: process.env['WANMAN_AGENT_USER'],
+    });
+
+    this.registerEventLogger(this.currentProcess);
+    this.registerSessionIdCapture(this.currentProcess);
+
+    // End stdin — single-shot execution
+    this.currentProcess.proc.stdin?.end();
+
+    let budgetTimer: ReturnType<typeof setTimeout> | null = null;
+    if (this.timeBudgetMs && this.currentProcess) {
+      const proc = this.currentProcess;
+      budgetTimer = setTimeout(() => {
+        log.warn('time budget exceeded, killing agent', {
+          agent: this.definition.name, budgetMs: this.timeBudgetMs,
+        });
+        proc.kill();
+      }, this.timeBudgetMs);
+    }
+
+    const exitCode = await this.currentProcess.wait();
+    if (budgetTimer) clearTimeout(budgetTimer);
+    this.currentProcess = null;
+    return exitCode;
   }
 
   private updateTokenUsage(event: AgentRunEvent): void {

--- a/packages/runtime/src/agent-process.ts
+++ b/packages/runtime/src/agent-process.ts
@@ -146,6 +146,33 @@ export class AgentProcess {
     hasAutonomousWork?: AutonomousWorkChecker,
     envProvider?: EnvironmentProvider,
   ) {
+    // `idle_cached` is Claude-only: the resume mechanism relies on capturing
+    // Claude's `system/init` session id and passing it back as `--resume <id>`.
+    // Codex has no equivalent in this runtime today, so pairing `idle_cached`
+    // with a non-Claude runtime would silently degrade to `on-demand`
+    // semantics (no preserved context).
+    //
+    // Reject at construction using the *effective* runtime (i.e. honoring the
+    // `WANMAN_RUNTIME` env override, not just the declared `agent.runtime`)
+    // so an operator who runs `WANMAN_RUNTIME=codex wanman start` against an
+    // agents.json with idle_cached agents sees the problem at startup, not
+    // after wondering why context is being lost across triggers.
+    if (definition.lifecycle === 'idle_cached') {
+      const effectiveRuntime = resolveAgentRuntime(definition);
+      if (effectiveRuntime !== 'claude') {
+        const declared = definition.runtime ?? '(default)';
+        const overridden = process.env['WANMAN_RUNTIME'] && process.env['WANMAN_RUNTIME'] !== definition.runtime
+          ? ` (forced by WANMAN_RUNTIME=${process.env['WANMAN_RUNTIME']})`
+          : '';
+        throw new Error(
+          `Agent "${definition.name}" has lifecycle "idle_cached" but the effective runtime is "${effectiveRuntime}"${overridden}. `
+          + `idle_cached only works with the Claude runtime — it relies on \`claude --resume\` to restore conversation context across triggers, `
+          + `which Codex has no equivalent for in this runtime. `
+          + `Either keep the runtime as "claude" (declared: "${declared}") or change the lifecycle to "on-demand".`
+        );
+      }
+    }
+
     this.definition = definition;
     this.relay = relay;
     this.workDir = workDir;
@@ -396,6 +423,10 @@ export class AgentProcess {
     const runEnv = { ...this.extraEnv, ...dynamicEnv };
     const reasoningEffort = resolveCodexReasoningEffort(runEnv, runtime);
     const fast = resolveCodexFast(runEnv, runtime);
+    // `idle_cached` agents always pass the captured Claude session id (if
+    // any) — the constructor already rejected the lifecycle paired with a
+    // non-Claude effective runtime, so we can rely on `runtime === 'claude'`
+    // here without re-checking.
     const resumeSessionId = this.definition.lifecycle === 'idle_cached'
       ? this.lastSessionId ?? undefined
       : undefined;

--- a/packages/runtime/src/claude-adapter.ts
+++ b/packages/runtime/src/claude-adapter.ts
@@ -11,6 +11,7 @@ export class ClaudeAdapter implements AgentAdapter {
       cwd: opts.cwd,
       initialMessage: opts.initialMessage,
       sessionId: opts.sessionId,
+      ...(opts.resumeSessionId ? { resumeSessionId: opts.resumeSessionId } : {}),
       env: opts.env,
       runAsUser: opts.runAsUser,
     });

--- a/packages/runtime/src/claude-code.ts
+++ b/packages/runtime/src/claude-code.ts
@@ -12,6 +12,51 @@ import { createLogger } from './logger.js';
 
 const log = createLogger('claude-code');
 
+/**
+ * Patterns Claude Code emits when `--resume <id>` references a session the
+ * local CLI no longer has. Recorded across versions:
+ *
+ * - 2.1.119+ (stdout `result` event errors / stderr): `No conversation found with session ID: <id>`
+ * - older / alt wordings:                              `No session found`, `session not found`,
+ *                                                      `session does not exist`, `session unavailable`,
+ *                                                      `could not resume`, `could not find session`,
+ *                                                      `conversation not found`
+ *
+ * The CLI wording has shifted at least once already (`session` → `conversation`),
+ * so the match is intentionally permissive on either noun. Keep this list
+ * here, not inlined, so future CLI wording bumps add one regex alternative
+ * instead of grepping the file. If patterns drift further, the structured
+ * `result.errors` payload (also matched against this regex) is the more
+ * stable surface — we already check that channel.
+ */
+const RESUME_MISSING_PATTERN =
+  /no\s+(?:conversation|session)\s+found|(?:conversation|session)\s+(?:not\s+found|does\s+not\s+exist|unavailable)|could\s+not\s+(?:resume|find\s+(?:conversation|session))/i;
+
+/**
+ * Pull every plausible error-text field off a Claude `result` event and
+ * concatenate them. Claude emits errors in a few shapes depending on
+ * subtype: as `result` (string), `errors` (array of strings or objects),
+ * or `error` (single string). We check all of them so the resume-miss
+ * regex catches the message wherever the CLI puts it that day.
+ */
+function resultErrorText(event: ClaudeEvent): string {
+  const parts: string[] = [];
+  if (typeof event.result === 'string' && event.result.trim()) parts.push(event.result.trim());
+  const errors = (event as Record<string, unknown>)['errors'];
+  if (Array.isArray(errors)) {
+    for (const err of errors) {
+      if (typeof err === 'string' && err.trim()) parts.push(err.trim());
+      else if (err && typeof err === 'object') {
+        const message = (err as Record<string, unknown>)['message'];
+        if (typeof message === 'string' && message.trim()) parts.push(message.trim());
+      }
+    }
+  }
+  const error = (event as Record<string, unknown>)['error'];
+  if (typeof error === 'string' && error.trim()) parts.push(error.trim());
+  return parts.join(' | ');
+}
+
 /** Events emitted by the Claude Code process via JSONL stdout */
 export interface ClaudeEvent extends Record<string, unknown> {
   type: string;
@@ -161,6 +206,24 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
         if (event.type === 'result') {
           const text = typeof event.result === 'string' ? event.result : JSON.stringify(event.result);
           for (const handler of resultHandlers) handler(text, event.is_error ?? false);
+
+          // Claude Code 2.1.119+ surfaces the stale-resume failure on the
+          // structured `result` event (is_error + "No conversation found
+          // with session ID: ..."), not just stderr. Detecting it here is
+          // more stable than grepping stderr because the JSONL contract is
+          // versioned by Anthropic, while the stderr text has already
+          // shifted once (`session` → `conversation`).
+          if (
+            resumeSessionId
+            && !resumeMissed
+            && event.is_error === true
+          ) {
+            const errorText = resultErrorText(event);
+            if (errorText && RESUME_MISSING_PATTERN.test(errorText)) {
+              resumeMissed = true;
+              log.warn('resume session missing (result event)', { resumeSessionId, text: errorText.slice(0, 200) });
+            }
+          }
         }
       } catch {
         // Skip unparseable lines
@@ -168,8 +231,9 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
     });
   }
 
-  // Log stderr — and watch for the "session not found" signal that Claude
-  // emits when `--resume <id>` references a session the local CLI has lost.
+  // Log stderr — and watch for the same "session/conversation not found"
+  // signal as a fallback in case the CLI version writes the failure to
+  // stderr instead of (or in addition to) the JSONL result event.
   if (proc.stderr) {
     proc.stderr.on('data', (data: Buffer) => {
       const text = data.toString().trim();
@@ -177,10 +241,10 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
       if (
         resumeSessionId
         && !resumeMissed
-        && /no\s+session\s+found|session\s+(?:not\s+found|does\s+not\s+exist|unavailable)|could\s+not\s+(?:resume|find\s+session)/i.test(text)
+        && RESUME_MISSING_PATTERN.test(text)
       ) {
         resumeMissed = true;
-        log.warn('resume session missing', { resumeSessionId, text: text.slice(0, 200) });
+        log.warn('resume session missing (stderr)', { resumeSessionId, text: text.slice(0, 200) });
       }
       log.warn('stderr', { text: text.slice(0, 500) });
     });

--- a/packages/runtime/src/claude-code.ts
+++ b/packages/runtime/src/claude-code.ts
@@ -39,8 +39,21 @@ export interface ClaudeCodeProcess {
   onEvent(handler: (event: ClaudeEvent) => void): void;
   /** Register a handler for the final result */
   onResult(handler: (result: string, isError: boolean) => void): void;
+  /**
+   * Register a handler invoked when Claude reports its session id (via the
+   * `system/init` event). Use this to persist the id and pass it back as
+   * `resumeSessionId` on the next spawn.
+   */
+  onSessionId(handler: (sessionId: string) => void): void;
   /** Register a handler for process exit */
   onExit(handler: (code: number) => void): void;
+  /**
+   * True iff Claude refused to resume the requested `resumeSessionId`
+   * (i.e. the session was not found locally). Callers can check this after
+   * exit and retry the spawn without `resumeSessionId` for cold-start
+   * recovery.
+   */
+  resumeMissed(): boolean;
 }
 
 export interface SpawnOptions {
@@ -50,6 +63,14 @@ export interface SpawnOptions {
   /** Initial user message to send immediately after spawn */
   initialMessage?: string;
   sessionId?: string;
+  /**
+   * If set, append `--resume <id>` to the Claude CLI args so the new process
+   * picks up where the previous process left off. The previous run's session
+   * id is reported via `onSessionId`. If the local Claude session store has
+   * dropped the id (rotated, manually deleted, etc.) the spawn surfaces this
+   * via `resumeMissed()` so the caller can retry without the flag.
+   */
+  resumeSessionId?: string;
   /** Extra environment variables to inject into the spawned process */
   env?: Record<string, string>;
   /** Run claude as this user (via runuser). When unset, runs as current user. */
@@ -64,7 +85,7 @@ export interface SpawnOptions {
  * get structured JSONL on stdout.
  */
 export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
-  const { model, systemPrompt, cwd, initialMessage, sessionId } = opts;
+  const { model, systemPrompt, cwd, initialMessage, sessionId, resumeSessionId } = opts;
 
   const claudeArgs = [
     '--model', model,
@@ -74,6 +95,10 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
     '--verbose',
     '--system-prompt', systemPrompt,
   ];
+
+  if (resumeSessionId) {
+    claudeArgs.push('--resume', resumeSessionId);
+  }
 
   // When running as root and runAsUser is set, use runuser to switch user
   const runAsUser = opts.runAsUser;
@@ -104,7 +129,10 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
 
   const eventHandlers: Array<(event: ClaudeEvent) => void> = [];
   const resultHandlers: Array<(result: string, isError: boolean) => void> = [];
+  const sessionIdHandlers: Array<(sessionId: string) => void> = [];
   const exitHandlers: Array<(code: number) => void> = [];
+  let observedSessionId: string | null = null;
+  let resumeMissed = false;
 
   // Parse JSONL from stdout
   let rl: ReadlineInterface | null = null;
@@ -115,6 +143,19 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
       try {
         const event = JSON.parse(line.trim()) as ClaudeEvent;
         for (const handler of eventHandlers) handler(event);
+
+        // Capture the session id from system/init so callers can persist it
+        // for `resumeSessionId` on the next spawn.
+        if (
+          event.type === 'system'
+          && event.subtype === 'init'
+          && typeof event.session_id === 'string'
+          && event.session_id
+          && observedSessionId !== event.session_id
+        ) {
+          observedSessionId = event.session_id;
+          for (const handler of sessionIdHandlers) handler(event.session_id);
+        }
 
         // Detect final result
         if (event.type === 'result') {
@@ -127,11 +168,21 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
     });
   }
 
-  // Log stderr
+  // Log stderr — and watch for the "session not found" signal that Claude
+  // emits when `--resume <id>` references a session the local CLI has lost.
   if (proc.stderr) {
     proc.stderr.on('data', (data: Buffer) => {
       const text = data.toString().trim();
-      if (text) log.warn('stderr', { text: text.slice(0, 500) });
+      if (!text) return;
+      if (
+        resumeSessionId
+        && !resumeMissed
+        && /no\s+session\s+found|session\s+(?:not\s+found|does\s+not\s+exist|unavailable)|could\s+not\s+(?:resume|find\s+session)/i.test(text)
+      ) {
+        resumeMissed = true;
+        log.warn('resume session missing', { resumeSessionId, text: text.slice(0, 200) });
+      }
+      log.warn('stderr', { text: text.slice(0, 500) });
     });
   }
 
@@ -187,7 +238,12 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
 
     onEvent(handler) { eventHandlers.push(handler); },
     onResult(handler) { resultHandlers.push(handler); },
+    onSessionId(handler) {
+      sessionIdHandlers.push(handler);
+      if (observedSessionId) handler(observedSessionId);
+    },
     onExit(handler) { exitHandlers.push(handler); },
+    resumeMissed() { return resumeMissed; },
   };
 
   // Send initial message if provided

--- a/packages/runtime/src/loop-event-bus.ts
+++ b/packages/runtime/src/loop-event-bus.ts
@@ -125,7 +125,7 @@ export class LoopEventBus {
       agents: agentStates.map(a => ({
         name: a.name,
         state: a.state as 'running' | 'idle' | 'stopped',
-        lifecycle: a.lifecycle as '24/7' | 'on-demand',
+        lifecycle: a.lifecycle as '24/7' | 'on-demand' | 'idle_cached',
       })),
       taskTransitions: this.taskTransitions,
       artifactsCreated: this.artifactsCreated,

--- a/packages/runtime/src/loop-events.ts
+++ b/packages/runtime/src/loop-events.ts
@@ -41,7 +41,7 @@ export interface AgentSpawned {
   runId: string
   loop: number
   agent: string
-  lifecycle: '24/7' | 'on-demand'
+  lifecycle: '24/7' | 'on-demand' | 'idle_cached'
   trigger: 'startup' | 'message' | 'steer' | 'cron' | 'backlog-drain'
   timestamp: string
 }
@@ -120,7 +120,7 @@ export interface LoopSnapshot {
   agents: Array<{
     name: string
     state: 'running' | 'idle' | 'stopped'
-    lifecycle: '24/7' | 'on-demand'
+    lifecycle: '24/7' | 'on-demand' | 'idle_cached'
   }>
   taskTransitions: number
   artifactsCreated: number

--- a/packages/runtime/src/supervisor.ts
+++ b/packages/runtime/src/supervisor.ts
@@ -652,17 +652,27 @@ ${activePaths}`;
         }
       });
 
-      // Wake on-demand agents when any message arrives (not just steer)
+      // Wake on-demand / idle_cached agents when any message arrives (not just steer)
       this.relay.setNewMessageCallback((agentName) => {
         const agent = this.agents.get(agentName);
-        if (agent && agent.definition.lifecycle === 'on-demand' && agent.state === 'idle') {
+        if (
+          agent
+          && (agent.definition.lifecycle === 'on-demand' || agent.definition.lifecycle === 'idle_cached')
+          && agent.state === 'idle'
+        ) {
           // Check if any assigned task for this agent has unmet dependencies
           const blocked = this.hasBlockedTasksOnly(agentName);
           if (blocked) {
-            log.info('on-demand agent has only blocked tasks, deferring', { agent: agentName });
+            log.info('idle agent has only blocked tasks, deferring', {
+              agent: agentName,
+              lifecycle: agent.definition.lifecycle,
+            });
             return;
           }
-          log.info('waking on-demand agent for new message', { agent: agentName });
+          log.info('waking idle agent for new message', {
+            agent: agentName,
+            lifecycle: agent.definition.lifecycle,
+          });
           agent.trigger();
         }
       });
@@ -673,9 +683,12 @@ ${activePaths}`;
   private initCronScheduler(): void {
     this.cronScheduler = new CronScheduler((agentName, expression) => {
       this.relay.send('system', agentName, 'cron', { expression }, 'normal');
-      // For on-demand agents, also trigger them
+      // For idle agents (on-demand / idle_cached), also trigger them
       const agent = this.agents.get(agentName);
-      if (agent && agent.definition.lifecycle === 'on-demand') {
+      if (
+        agent
+        && (agent.definition.lifecycle === 'on-demand' || agent.definition.lifecycle === 'idle_cached')
+      ) {
         agent.handleSteer();
       }
     });
@@ -1699,8 +1712,16 @@ ${activePaths}`;
       }
       for (const agentName of unblockedAgents) {
         const agent = this.agents.get(agentName);
-        if (agent && agent.definition.lifecycle === 'on-demand' && agent.state === 'idle') {
-          log.info('waking previously-blocked on-demand agent', { agent: agentName, unlockedBy: completedTaskId });
+        if (
+          agent
+          && (agent.definition.lifecycle === 'on-demand' || agent.definition.lifecycle === 'idle_cached')
+          && agent.state === 'idle'
+        ) {
+          log.info('waking previously-blocked idle agent', {
+            agent: agentName,
+            lifecycle: agent.definition.lifecycle,
+            unlockedBy: completedTaskId,
+          });
           agent.trigger();
         }
       }


### PR DESCRIPTION
## Problem

A stateful long-running agent has no good lifecycle option today. `24/7` keeps the process always-respawning but every iteration is a fresh Claude session, losing context. `on-demand` saves CPU but is also stateless — every trigger cold-starts.

## Behavior

Add `idle_cached` (Claude-only): idle like `on-demand`, but the runtime captures the Claude `session_id` from `system/init` events and passes it back as `--resume <id>` on the next trigger so prior context is restored. The first trigger always cold-starts. If the local Claude CLI no longer has the captured session, the runtime detects the failure (stderr + `resumeMissed()`), clears the cached id, and re-spawns once without `--resume` — no agent gets stranded.

`AgentProcess` rejects `idle_cached` paired with a non-Claude effective runtime at construction (honoring `WANMAN_RUNTIME` env override) so the misconfig fails loudly at startup instead of silently degrading.

`24/7` and `on-demand` semantics are unchanged. Codex adapter is untouched.

## Tests

Full suite: **1105 passed / 8 skipped / 0 failed** • Lines **90.33%**.

New coverage: `--resume` arg propagation, `system/init` session-id capture (no double-fire / late-handler replay), `resumeMissed` from stderr, idle_cached cold-starts the first trigger, resumes the captured id on the next, falls back when stale, on-demand never resumes (regression guard), constructor rejects declared-codex / `WANMAN_RUNTIME=codex` / accepts default + declared claude.