### PR TITLE
修复 npm link 后 wanman 静默退出

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -3,6 +3,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 // Mock all command modules
 vi.mock('./commands/send.js', () => ({ sendCommand: vi.fn() }));
@@ -193,6 +196,16 @@ describe('direct execution detection', () => {
     const entry = '/tmp/wanman-entry.js'
 
     expect(isDirectCliExecution(new URL(`file://${entry}`).href, ['node', entry])).toBe(true)
+  })
+
+  it('returns true when argv entry is a symlink to the import meta URL', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wanman-cli-'))
+    const entry = path.join(tempDir, 'index.js')
+    const linkedEntry = path.join(tempDir, 'wanman')
+    fs.writeFileSync(entry, '')
+    fs.symlinkSync(entry, linkedEntry)
+
+    expect(isDirectCliExecution(new URL(`file://${entry}`).href, ['node', linkedEntry])).toBe(true)
   })
 
   it('returns false without an argv entry', () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,6 +9,7 @@
  *   wanman escalate <message>
  */
 
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { sendCommand } from './commands/send.js';
@@ -142,7 +143,11 @@ export function isDirectCliExecution(metaUrl = import.meta.url, argv = process.a
   if (!entry) return false
 
   try {
-    return path.resolve(entry) === path.resolve(fileURLToPath(metaUrl))
+    const entryPath = path.resolve(entry)
+    const metaPath = path.resolve(fileURLToPath(metaUrl))
+    if (entryPath === metaPath) return true
+
+    return fs.realpathSync(entryPath) === fs.realpathSync(metaPath)
   } catch {
     return false
   }


### PR DESCRIPTION
## 问题

通过 `npm link` 本地安装 `@wanman/cli` 后，执行 `wanman` 或 `wanman --help` 会静默退出，退出码为 0 但没有任何输出。

根因是 CLI 入口的 `isDirectCliExecution()` 只比较 `process.argv[1]` 和 `import.meta.url` 对应的普通解析路径。`npm link` 暴露的 bin 是 symlink，`process.argv[1]` 指向全局 bin 链接路径，而 `import.meta.url` 指向真实的 `dist/index.js` 路径，两者字符串不相等，导致入口没有调用 `run()`。

## 变更

- 在入口检测中先保留原有路径比较，再用 `fs.realpathSync()` 解析 symlink 后比较真实路径。
- 增加 symlink 入口场景的回归测试，覆盖 `npm link` 这类全局 bin 链接执行方式。

## 验证

- `pnpm --filter @wanman/cli typecheck`
- `pnpm --filter @wanman/cli test -- src/index.test.ts`
- `pnpm --filter @wanman/cli test`
- 本地验证 `wanman --help` 可以正常输出帮助文本
