### PR TITLE
fix(cli): suppress duplicate PR nudges for active owner

### DIFF
--- a/packages/cli/src/takeover-local.test.ts
+++ b/packages/cli/src/takeover-local.test.ts
@@ -137,7 +137,7 @@ describe('local takeover progress helpers', () => {
 })
 
 describe('maybeNudgeLocalPrExecution', () => {
-  it('steers implementers and mission control when progress has no PR', async () => {
+  it('steers only the branch owner and ceo when progress has no PR', async () => {
     const sendMessage = vi.fn().mockResolvedValue(undefined)
     const state = makeState({
       activeBranch: 'wanman/task',
@@ -149,14 +149,18 @@ describe('maybeNudgeLocalPrExecution', () => {
         { id: '2', title: 'Review', status: 'in_progress', assignee: 'dev-1', priority: 1 },
         { id: '3', title: 'Done', status: 'done', assignee: 'devops', priority: 1 },
       ],
+      capsules: [
+        { id: 'capsule-1', status: 'open', ownerAgent: 'dev', branch: 'wanman/task', taskId: '1' },
+        { id: 'capsule-2', status: 'open', ownerAgent: 'dev-1', branch: 'wanman/other-task', taskId: '2' },
+      ],
     })
     const nudgeState: { lastSignature?: string; lastSentAt?: number } = {}
 
     await expect(maybeNudgeLocalPrExecution({ sendMessage } as never, state, nudgeState)).resolves.toBe(true)
 
-    expect(collectPrNudgeRecipients(state)).toEqual(['dev', 'dev-1', 'ceo'])
+    expect(collectPrNudgeRecipients(state)).toEqual(['dev', 'ceo'])
     expect(buildPrNudgeSignature(state)).toContain('wanman/task')
-    expect(sendMessage).toHaveBeenCalledTimes(3)
+    expect(sendMessage).toHaveBeenCalledTimes(2)
     expect(sendMessage).toHaveBeenCalledWith(expect.objectContaining({
       from: 'takeover-pr-allocator',
       to: 'dev',
@@ -165,7 +169,66 @@ describe('maybeNudgeLocalPrExecution', () => {
     expect(nudgeState.lastSignature).toBeDefined()
 
     await expect(maybeNudgeLocalPrExecution({ sendMessage } as never, state, nudgeState)).resolves.toBe(false)
-    expect(sendMessage).toHaveBeenCalledTimes(3)
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it('suppresses PR nudges when a shared branch cannot be mapped to one owner', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined)
+    const state = makeState({
+      activeBranch: 'wanman/task',
+      branchAhead: 2,
+      hasUpstream: true,
+      modifiedFiles: ['src/app.ts'],
+      tasks: [
+        { id: '1', title: 'Implement', status: 'assigned', assignee: 'dev', priority: 1 },
+        { id: '2', title: 'Review', status: 'assigned', assignee: 'dev-1', priority: 1 },
+      ],
+      capsules: [
+        { id: 'capsule-1', status: 'open', ownerAgent: 'dev', branch: 'wanman/one', taskId: '1' },
+        { id: 'capsule-2', status: 'open', ownerAgent: 'dev-1', branch: 'wanman/two', taskId: '2' },
+      ],
+    })
+
+    expect(collectPrNudgeRecipients(state)).toEqual([])
+    await expect(maybeNudgeLocalPrExecution({ sendMessage } as never, state, {})).resolves.toBe(false)
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the only implementer when there is no capsule mapping yet', async () => {
+    const state = makeState({
+      activeBranch: 'wanman/task',
+      tasks: [
+        { id: '1', title: 'Implement', status: 'assigned', assignee: 'dev', priority: 1 },
+      ],
+    })
+
+    expect(collectPrNudgeRecipients(state)).toEqual(['dev', 'ceo'])
+  })
+
+  it('suppresses PR nudges while the mapped branch owner is already running', async () => {
+    const sendMessage = vi.fn().mockResolvedValue(undefined)
+    const state = makeState({
+      activeBranch: 'wanman/task',
+      branchAhead: 1,
+      hasUpstream: true,
+      modifiedFiles: ['src/app.ts'],
+      health: {
+        agents: [
+          { name: 'ceo', state: 'idle', lifecycle: '24/7' },
+          { name: 'dev', state: 'running', lifecycle: 'on-demand' },
+          { name: 'dev-1', state: 'idle', lifecycle: 'on-demand' },
+        ],
+      },
+      tasks: [
+        { id: '1', title: 'Implement', status: 'in_progress', assignee: 'dev', priority: 1 },
+      ],
+      capsules: [
+        { id: 'capsule-1', status: 'open', ownerAgent: 'dev', branch: 'wanman/task', taskId: '1' },
+      ],
+    })
+
+    await expect(maybeNudgeLocalPrExecution({ sendMessage } as never, state, {})).resolves.toBe(false)
+    expect(sendMessage).not.toHaveBeenCalled()
   })
 
   it('does not send PR nudges when a PR already exists or no branch work is ready', async () => {

--- a/packages/cli/src/takeover-local.ts
+++ b/packages/cli/src/takeover-local.ts
@@ -336,18 +336,48 @@ function isTakeoverFeatureBranch(branch?: string): boolean {
   return !!branch && /^(wanman|fix|feat|chore|docs)\//.test(branch)
 }
 
+function isImplementerAgent(agent?: string): boolean {
+  return !!agent && (agent === 'dev' || agent === 'devops' || /^dev-\d+$/.test(agent))
+}
+
+function isActiveCapsuleStatus(status: string): boolean {
+  return status === 'open' || status === 'in_review'
+}
+
+function isAgentRunning(state: LocalObservationState, agentName: string): boolean {
+  return state.health.agents.some(agent => agent.name === agentName && agent.state === 'running')
+}
+
 /** @internal exported for testing */
 export function collectPrNudgeRecipients(state: LocalObservationState): string[] {
-  const recipients = new Set<string>()
-  for (const task of state.tasks) {
-    if (!task.assignee) continue
-    if (task.status === 'done') continue
-    if (task.assignee === 'dev' || task.assignee === 'devops' || /^dev-\d+$/.test(task.assignee)) {
-      recipients.add(task.assignee)
+  const implementers = [...new Set(
+    state.tasks
+      .filter(task => task.status !== 'done' && task.status !== 'failed' && isImplementerAgent(task.assignee))
+      .map(task => task.assignee as string),
+  )]
+  if (implementers.length === 0) return []
+
+  if (state.activeBranch) {
+    const branchOwners = [...new Set(
+      state.capsules
+        .filter(capsule => capsule.branch === state.activeBranch && isActiveCapsuleStatus(capsule.status) && isImplementerAgent(capsule.ownerAgent))
+        .map(capsule => capsule.ownerAgent as string),
+    )]
+    if (branchOwners.length > 0) {
+      return [...branchOwners, 'ceo']
     }
   }
-  recipients.add('ceo')
-  return [...recipients]
+
+  if (implementers.length === 1) {
+    return [...implementers, 'ceo']
+  }
+
+  const activeImplementerCapsules = state.capsules.filter(capsule => isActiveCapsuleStatus(capsule.status) && isImplementerAgent(capsule.ownerAgent))
+  if (activeImplementerCapsules.length > 1) {
+    return []
+  }
+
+  return [...implementers, 'ceo']
 }
 
 /** @internal exported for testing */
@@ -359,7 +389,7 @@ export function buildPrNudgeSignature(state: LocalObservationState): string {
     modifiedFiles: state.modifiedFiles,
     recipients: collectPrNudgeRecipients(state),
     tasks: state.tasks
-      .filter(task => task.assignee && (task.assignee === 'dev' || task.assignee === 'devops' || /^dev-\d+$/.test(task.assignee)))
+      .filter(task => isImplementerAgent(task.assignee))
       .map(task => ({ id: task.id, status: task.status, assignee: task.assignee })),
   })
 }
@@ -395,6 +425,7 @@ export async function maybeNudgeLocalPrExecution(
 
   const recipients = collectPrNudgeRecipients(state)
   if (recipients.length === 0) return false
+  if (recipients.some(agent => agent !== 'ceo' && isAgentRunning(state, agent))) return false
 
   const signature = buildPrNudgeSignature(state)
   const now = Date.now()


### PR DESCRIPTION
## Summary
- stop `maybeNudgeLocalPrExecution` from nudging the mapped branch owner when that non-CEO owner is already running in the runtime health snapshot
- keep the CEO nudge path intact for cases where no active owner run is present
- add regression coverage for the active-owner suppression path

## Verification
- `pnpm -C /Users/kending/github.com/checksu/wanman/.task-worktrees/680d569d --filter @wanman/cli exec vitest run src/takeover-local.test.ts`
  - `Test Files  1 passed (1)`
  - `Tests  12 passed (12)`

## Notes
- Running the package `test` script with a filename argument still picks up an unrelated existing failure in `src/commands/send.test.ts` on current head (`from: devops` vs expected `from: cli`). This branch does not modify that area.