### PR TITLE
Fix Codex login URL parsing with colored CLI output

### DIFF
--- a/packages/runtime/src/__tests__/auth-manager.spawn.test.ts
+++ b/packages/runtime/src/__tests__/auth-manager.spawn.test.ts
@@ -104,6 +104,24 @@ describe('AuthManager spawn-backed flows', () => {
     expect(manager.getLoginStatus('codex').status).toBe('authenticated')
   })
 
+  it('strips terminal color sequences from captured Codex login details', async () => {
+    const child = makeChild()
+    spawnMock.mockReturnValueOnce(child)
+    const manager = new AuthManager()
+    const result = manager.startLogin('codex')
+
+    child.stdout.emit('data', Buffer.from(
+      'Open \u001b[94mhttps://auth.openai.com/device\u001b[0m and enter \u001b[94mABCD-12345\u001b[0m',
+    ))
+
+    await expect(result).resolves.toEqual({
+      name: 'codex',
+      status: 'pending',
+      loginUrl: 'https://auth.openai.com/device',
+      loginCode: 'ABCD-12345',
+    })
+  })
+
   it('returns an error when login spawn fails before printing a URL', async () => {
     const child = makeChild()
     spawnMock.mockReturnValueOnce(child)

--- a/packages/runtime/src/auth-manager.ts
+++ b/packages/runtime/src/auth-manager.ts
@@ -11,6 +11,11 @@ import { createLogger } from './logger.js';
 
 const log = createLogger('auth-manager');
 const AUTH_CHECK_TIMEOUT_MS = 1500;
+const ANSI_ESCAPE_REGEX = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+
+function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE_REGEX, '');
+}
 
 /** Active login session for a provider */
 interface LoginSession {
@@ -203,7 +208,7 @@ export class AuthManager {
       let resolved = false;
 
       const processOutput = (data: Buffer) => {
-        const text = data.toString();
+        const text = stripAnsi(data.toString());
         log.debug('login stdout', { provider, text: text.trim() });
 
         // Try to extract code


### PR DESCRIPTION
## Summary
- Strip ANSI terminal escape sequences from runtime login output before extracting provider login URLs and codes.
- Add a regression test for colored Codex device-auth output.

## Verification
- `TMPDIR=.tmp-vitest corepack pnpm --filter @wanman/runtime test -- auth-manager.spawn.test.ts`
- `corepack pnpm --filter @wanman/runtime typecheck`

Fixes #13