### PR TITLE
Fix Codex auth URL parsing

### DIFF
--- a/packages/runtime/src/__tests__/auth-manager.spawn.test.ts
+++ b/packages/runtime/src/__tests__/auth-manager.spawn.test.ts
@@ -85,18 +85,23 @@ describe('AuthManager spawn-backed flows', () => {
     expect(child.kill).toHaveBeenCalled()
   })
 
-  it('captures Codex device login URL and code from stdout and records success on close', async () => {
+  it('captures Codex device login URL and code from colorized stdout and records success on close', async () => {
     const child = makeChild()
     spawnMock.mockReturnValueOnce(child)
     const manager = new AuthManager()
     const result = manager.startLogin('codex')
 
-    child.stdout.emit('data', Buffer.from('Open https://auth.openai.com/device and enter ABCD-12345'))
+    child.stdout.emit('data', Buffer.from([
+      'Open this link in your browser',
+      '   \x1B[94mhttps://auth.openai.com/codex/device\x1B[0m',
+      'Enter this one-time code',
+      '   \x1B[94mABCD-12345\x1B[0m',
+    ].join('\n')))
 
     await expect(result).resolves.toEqual({
       name: 'codex',
       status: 'pending',
-      loginUrl: 'https://auth.openai.com/device',
+      loginUrl: 'https://auth.openai.com/codex/device',
       loginCode: 'ABCD-12345',
     })
 

--- a/packages/runtime/src/auth-manager.ts
+++ b/packages/runtime/src/auth-manager.ts
@@ -12,6 +12,13 @@ import { createLogger } from './logger.js';
 const log = createLogger('auth-manager');
 const AUTH_CHECK_TIMEOUT_MS = 1500;
 
+function stripTerminalControlSequences(value: string): string {
+  return value
+    .replace(/\x1B\][^\x07]*(?:\x07|\x1B\\)/g, '')
+    .replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\x1B[@-Z\\-_]/g, '');
+}
+
 /** Active login session for a provider */
 interface LoginSession {
   provider: AuthProviderName;
@@ -203,7 +210,7 @@ export class AuthManager {
       let resolved = false;
 
       const processOutput = (data: Buffer) => {
-        const text = data.toString();
+        const text = stripTerminalControlSequences(data.toString());
         log.debug('login stdout', { provider, text: text.trim() });
 
         // Try to extract code


### PR DESCRIPTION
Fixes #15.

Summary:
- Strip terminal control sequences from CLI login output before extracting provider URLs and device codes.
- Add a Codex regression test for colorized device-login output so the returned URL remains browser-safe.

Tests:
- pnpm --filter @wanman/runtime test -- auth-manager.spawn.test.ts
- pnpm --filter @wanman/runtime test -- auth.test.ts
- pnpm --filter @wanman/runtime typecheck