### PR TITLE
fix(runtime): handle trigger() rejections when waking idle agents

### DIFF
--- a/packages/runtime/src/__tests__/supervisor.test.ts
+++ b/packages/runtime/src/__tests__/supervisor.test.ts
@@ -896,7 +896,7 @@ describe('Supervisor', () => {
       const pingAgent = {
         definition: { lifecycle: 'on-demand' },
         state: 'idle',
-        trigger: vi.fn(),
+        trigger: vi.fn().mockResolvedValue(undefined),
       }
       ;(supervisor as unknown as { agents: Map<string, unknown> }).agents.set('ping', pingAgent)
 
@@ -925,6 +925,95 @@ describe('Supervisor', () => {
       expect(helpers.hasBlockedTasksOnly('ping')).toBe(false)
       expect(helpers.hasAutonomousWork('ping')).toBe(true)
       helpers.taskPool.listSync = originalListSync
+    })
+
+    it('survives trigger() rejections from woken agents (no unhandled rejection)', async () => {
+      const unhandled: unknown[] = []
+      const onUnhandled = (reason: unknown) => { unhandled.push(reason) }
+      process.on('unhandledRejection', onUnhandled)
+      try {
+        const root = await supervisor.handleRpcAsync(rpc(RPC_METHODS.TASK_CREATE, {
+          title: 'Root task 2',
+          description: 'unblocks follow-up',
+          assignee: 'echo',
+        }))
+        const rootTask = root.result as { id: string }
+        await supervisor.handleRpcAsync(rpc(RPC_METHODS.TASK_CREATE, {
+          title: 'Blocked task 2',
+          description: 'waits on root',
+          assignee: 'ping',
+          dependsOn: [rootTask.id],
+        }))
+
+        // Plain function (not vi.fn()): vitest mocks attach internal handlers
+        // to returned promises, which would mask an unhandled rejection.
+        let triggerCalls = 0
+        const pingAgent = {
+          definition: { lifecycle: 'on-demand' },
+          state: 'idle',
+          trigger: () => {
+            triggerCalls++
+            return Promise.reject(new Error('spawn exploded'))
+          },
+        }
+        ;(supervisor as unknown as { agents: Map<string, unknown> }).agents.set('ping', pingAgent)
+
+        await supervisor.handleRpcAsync(rpc(RPC_METHODS.TASK_UPDATE, {
+          id: rootTask.id,
+          status: 'done',
+        }))
+        const helpers = supervisor as unknown as {
+          wakeUnblockedAgents(completedTaskId: string): void
+        }
+        // Note: marking the root task done already wakes unblocked agents
+        // internally, so trigger may fire more than once here.
+        expect(() => helpers.wakeUnblockedAgents(rootTask.id)).not.toThrow()
+        expect(triggerCalls).toBeGreaterThanOrEqual(1)
+        // Let the rejected trigger promise settle, then verify it was handled.
+        await new Promise(resolve => setImmediate(resolve))
+        await new Promise(resolve => setImmediate(resolve))
+        expect(unhandled).toEqual([])
+      } finally {
+        process.off('unhandledRejection', onUnhandled)
+      }
+    })
+
+    it('survives trigger() rejections when waking an idle agent for a new message', async () => {
+      const unhandled: unknown[] = []
+      const onUnhandled = (reason: unknown) => { unhandled.push(reason) }
+      process.on('unhandledRejection', onUnhandled)
+      try {
+        // Plain function (not vi.fn()): vitest mocks attach internal handlers
+        // to returned promises, which would mask an unhandled rejection.
+        let triggerCalls = 0
+        const pingAgent = {
+          definition: { lifecycle: 'on-demand' },
+          state: 'idle',
+          trigger: () => {
+            triggerCalls++
+            return Promise.reject(new Error('spawn exploded'))
+          },
+        }
+        ;(supervisor as unknown as { agents: Map<string, unknown> }).agents.set('ping', pingAgent)
+
+        // agent.send fires the relay new-message callback synchronously, which
+        // wakes the idle on-demand agent via trigger().
+        const res = supervisor.handleRpc(rpc(RPC_METHODS.AGENT_SEND, {
+          from: 'cli',
+          to: 'ping',
+          type: 'message',
+          payload: 'wake up',
+          priority: 'normal',
+        }))
+        expect(res.error).toBeUndefined()
+        expect(triggerCalls).toBe(1)
+        // Let the rejected trigger promise settle, then verify it was handled.
+        await new Promise(resolve => setImmediate(resolve))
+        await new Promise(resolve => setImmediate(resolve))
+        expect(unhandled).toEqual([])
+      } finally {
+        process.off('unhandledRejection', onUnhandled)
+      }
     })
 
     it('builds preamble/env providers from active skill snapshots and records run feedback', async () => {

--- a/packages/runtime/src/supervisor.ts
+++ b/packages/runtime/src/supervisor.ts
@@ -673,7 +673,12 @@ ${activePaths}`;
             agent: agentName,
             lifecycle: agent.definition.lifecycle,
           });
-          agent.trigger();
+          void agent.trigger().catch((err) => {
+            log.error('agent trigger failed', {
+              agent: agentName,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
         }
       });
     }
@@ -1722,7 +1727,12 @@ ${activePaths}`;
             lifecycle: agent.definition.lifecycle,
             unlockedBy: completedTaskId,
           });
-          agent.trigger();
+          void agent.trigger().catch((err) => {
+            log.error('agent trigger failed', {
+              agent: agentName,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

`AgentProcess.trigger()` is an async method that can reject (it awaits `relay.recv`, `credentialManager.ensureFresh()`, `runOneShot()`, and the preamble/env providers). The supervisor called it fire-and-forget — without `await` or `.catch()` — in two places:

1. Inside the `setNewMessageCallback` lambda that wakes idle on-demand / idle_cached agents when a message arrives.
2. Inside `wakeUnblockedAgents()` when a completed task unblocks dependent agents. The surrounding `try/catch` there does not cover the promise, since it is never awaited.

Any rejection became an unhandled promise rejection, which can crash the whole supervisor process.

## Fix

Both call sites now use:

```ts
void agent.trigger().catch((err) => {
  log.error('agent trigger failed', {
    agent: agentName,
    error: err instanceof Error ? err.message : String(err),
  });
});
```

This matches the existing `agent.start().catch(...)` error-handling pattern already used in `Supervisor.start()`.

## Tests

- Added two regression tests asserting that no `unhandledRejection` event is emitted when a woken agent's `trigger()` rejects, covering both the new-message wake path and the task-unblock wake path. Both tests fail without the fix and pass with it.
- The tests use plain function mocks rather than `vi.fn()`, because vitest mocks attach internal handlers to returned promises (for `mock.settledResults`), which would mask the unhandled rejection.
- Also tightened an existing loose mock (`trigger: vi.fn()` returned `undefined`, which is not a valid `Promise<void>`).

Full `@wanman/runtime` suite: 48 files, 716 passed / 8 skipped (pre-existing skips). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)