### PR TITLE
等待故事成果物同步完成后再返回

### DIFF
--- a/packages/runtime/src/__tests__/supervisor.test.ts
+++ b/packages/runtime/src/__tests__/supervisor.test.ts
@@ -67,6 +67,25 @@ function rpc(method: string, params?: Record<string, unknown>): JsonRpcRequest {
   return { jsonrpc: '2.0', id: 1, method, params }
 }
 
+function setStorySyncEnv(): () => void {
+  const previousEnv = {
+    WANMAN_SYNC_URL: process.env['WANMAN_SYNC_URL'],
+    WANMAN_SYNC_SECRET: process.env['WANMAN_SYNC_SECRET'],
+    WANMAN_STORY_ID: process.env['WANMAN_STORY_ID'],
+  }
+  process.env['WANMAN_SYNC_URL'] = 'https://api.example.com/api/sync'
+  process.env['WANMAN_SYNC_SECRET'] = 'sync-secret'
+  process.env['WANMAN_STORY_ID'] = 'story-1'
+  return () => {
+    if (previousEnv.WANMAN_SYNC_URL === undefined) delete process.env['WANMAN_SYNC_URL']
+    else process.env['WANMAN_SYNC_URL'] = previousEnv.WANMAN_SYNC_URL
+    if (previousEnv.WANMAN_SYNC_SECRET === undefined) delete process.env['WANMAN_SYNC_SECRET']
+    else process.env['WANMAN_SYNC_SECRET'] = previousEnv.WANMAN_SYNC_SECRET
+    if (previousEnv.WANMAN_STORY_ID === undefined) delete process.env['WANMAN_STORY_ID']
+    else process.env['WANMAN_STORY_ID'] = previousEnv.WANMAN_STORY_ID
+  }
+}
+
 describe('Supervisor', () => {
   let supervisor: Supervisor
   let tempWorkspace: string
@@ -814,6 +833,78 @@ describe('Supervisor', () => {
         else process.env['WANMAN_SYNC_SECRET'] = previousEnv.WANMAN_SYNC_SECRET
         if (previousEnv.WANMAN_STORY_ID === undefined) delete process.env['WANMAN_STORY_ID']
         else process.env['WANMAN_STORY_ID'] = previousEnv.WANMAN_STORY_ID
+        fetchSpy.mockRestore()
+      }
+    })
+
+    it('waits for the story artifact sync attempt before returning artifact.put', async () => {
+      const executeSQL = vi.fn().mockResolvedValue([{ id: 43, agent: 'ceo', kind: 'note' }])
+      ;(supervisor as unknown as { brainManager: unknown }).brainManager = {
+        isInitialized: true,
+        executeSQL,
+      }
+      const restoreEnv = setStorySyncEnv()
+      let resolveFetch: ((response: Response) => void) | undefined
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+        () => new Promise<Response>((resolve) => {
+          resolveFetch = resolve
+        }),
+      )
+
+      try {
+        const putPromise = supervisor.handleRpcAsync(rpc(RPC_METHODS.ARTIFACT_PUT, {
+          kind: 'note',
+          agent: 'ceo',
+          source: 'test',
+          confidence: 0.9,
+          path: 'notes/two.md',
+          content: 'hello again',
+          metadata: { topic: 'sync' },
+        }))
+        let settled = false
+        putPromise.finally(() => { settled = true })
+
+        await new Promise(resolve => setTimeout(resolve, 0))
+
+        expect(fetchSpy).toHaveBeenCalledWith(
+          'https://api.example.com/api/sync/artifact',
+          expect.objectContaining({ method: 'POST' }),
+        )
+        expect(settled).toBe(false)
+
+        resolveFetch?.(new Response(null, { status: 200 }))
+        const put = await putPromise
+        expect(put.error).toBeUndefined()
+      } finally {
+        restoreEnv()
+        fetchSpy.mockRestore()
+      }
+    })
+
+    it('keeps artifact.put successful when story artifact sync fails', async () => {
+      const executeSQL = vi.fn().mockResolvedValue([{ id: 44, agent: 'ceo', kind: 'note' }])
+      ;(supervisor as unknown as { brainManager: unknown }).brainManager = {
+        isInitialized: true,
+        executeSQL,
+      }
+      const restoreEnv = setStorySyncEnv()
+      const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('sync unavailable'))
+
+      try {
+        const put = await supervisor.handleRpcAsync(rpc(RPC_METHODS.ARTIFACT_PUT, {
+          kind: 'note',
+          agent: 'ceo',
+          source: 'test',
+          confidence: 0.9,
+          path: 'notes/three.md',
+          content: 'still stored',
+          metadata: { topic: 'sync-failure' },
+        }))
+
+        expect(put.error).toBeUndefined()
+        expect(executeSQL.mock.calls.at(-1)?.[0]).toContain('INSERT INTO artifacts')
+      } finally {
+        restoreEnv()
         fetchSpy.mockRestore()
       }
     })

--- a/packages/runtime/src/supervisor.ts
+++ b/packages/runtime/src/supervisor.ts
@@ -132,29 +132,38 @@ function normalizeThreadSyncMessageType(
   return inferHumanMessageType(payload, priority);
 }
 
-function postStorySyncArtifact(artifact: {
+async function postStorySyncArtifact(artifact: {
   id?: string;
   agent?: string;
   kind: string;
   path: string;
   content?: string | null;
   metadata?: Record<string, unknown>;
-}): void {
+}): Promise<void> {
   const syncUrl = process.env['WANMAN_SYNC_URL'];
   const syncSecret = process.env['WANMAN_SYNC_SECRET'];
   const syncStoryId = process.env['WANMAN_STORY_ID'];
   if (!syncUrl || !syncStoryId) return;
 
-  fetch(`${syncUrl}/artifact`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Story-Id': syncStoryId,
-      ...(syncSecret ? { 'X-Sync-Secret': syncSecret } : {}),
-    },
-    body: JSON.stringify(artifact),
-    signal: AbortSignal.timeout(5_000),
-  }).catch(() => {});
+  try {
+    const response = await fetch(`${syncUrl}/artifact`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Story-Id': syncStoryId,
+        ...(syncSecret ? { 'X-Sync-Secret': syncSecret } : {}),
+      },
+      body: JSON.stringify(artifact),
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!response.ok) {
+      log.warn('story artifact sync failed', { status: response.status });
+    }
+  } catch (err) {
+    log.warn('story artifact sync failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 export interface SupervisorOptions {
@@ -1438,7 +1447,7 @@ ${activePaths}`;
             });
           }
           // POST to external sync hook (best-effort)
-          postStorySyncArtifact({
+          await postStorySyncArtifact({
             id: String(insertedArtifact?.id ?? Date.now()),
             agent,
             kind,


### PR DESCRIPTION
Refs #18

## 摘要
- `artifact.put` 现在会等待故事成果物同步请求完成或超时后再返回，降低沙盒回收时成果物快照丢失的风险。
- 同步失败仍不阻断成果物入库，只记录告警，保持原有 best-effort 语义。
- 新增回归测试覆盖同步未完成时 RPC 不提前返回，以及同步失败不影响成果物存储。

## 验证
- 已运行 `@wanman/runtime` 的 `src/__tests__/supervisor.test.ts`。
- 已运行 `@wanman/runtime` typecheck。

相关目标测试和类型检查已通过。