### PR TITLE
fix(runtime): resume idle agents with pending work

### DIFF
--- a/packages/runtime/src/__tests__/agent-process.test.ts
+++ b/packages/runtime/src/__tests__/agent-process.test.ts
@@ -387,6 +387,35 @@ describe('AgentProcess', () => {
       expect(spawnClaudeCode).not.toHaveBeenCalled()
     })
 
+    it('should spawn without pending messages when runnable assigned work exists', async () => {
+      const { spawnClaudeCode } = await import('../claude-code.js')
+      waitDeferreds[0] = deferred<number>()
+      waitDeferreds[0].resolve(0)
+
+      const agent = new AgentProcess(
+        makeDef(),
+        relay,
+        '/tmp',
+        undefined,
+        undefined,
+        undefined,
+        () => '### Current Tasks\n- [task-1] Continue work',
+        undefined,
+        undefined,
+        () => true,
+      )
+
+      await agent.trigger()
+
+      expect(spawnClaudeCode).toHaveBeenCalledWith(expect.objectContaining({
+        initialMessage: expect.stringContaining('continue runnable assigned work'),
+      }))
+      expect(spawnClaudeCode).toHaveBeenCalledWith(expect.objectContaining({
+        initialMessage: expect.stringContaining('Current Tasks'),
+      }))
+      expect(agent.state).toBe('idle')
+    })
+
     it('should skip trigger when already running', async () => {
       waitDeferreds[0] = deferred<number>()
 

--- a/packages/runtime/src/__tests__/supervisor.test.ts
+++ b/packages/runtime/src/__tests__/supervisor.test.ts
@@ -35,6 +35,8 @@ vi.mock('../agent-process.js', () => {
       if (startShouldFail) throw new Error('spawn failed')
     }
     trigger() { return Promise.resolve() }
+    pause() {}
+    resume() {}
     stop() {}
     handleSteer() {}
   }
@@ -1014,6 +1016,66 @@ describe('Supervisor', () => {
       } finally {
         process.off('unhandledRejection', onUnhandled)
       }
+    })
+
+    it('wakes idle on-demand agents with pending messages when supervisor resumes', async () => {
+      const pingAgent = {
+        definition: { lifecycle: 'on-demand' },
+        state: 'running',
+        pause: vi.fn(),
+        resume: vi.fn(),
+        trigger: vi.fn().mockResolvedValue(undefined),
+      }
+      ;(supervisor as unknown as { agents: Map<string, unknown> }).agents.set('ping', pingAgent)
+
+      const sent = supervisor.handleRpc(rpc(RPC_METHODS.AGENT_SEND, {
+        from: 'cli',
+        to: 'ping',
+        type: 'message',
+        payload: 'resume backlog',
+        priority: 'normal',
+      }))
+      expect(sent.error).toBeUndefined()
+      expect(pingAgent.trigger).not.toHaveBeenCalled()
+
+      pingAgent.state = 'idle'
+      const resumed = await supervisor.handleRpcAsync(rpc(RPC_METHODS.SUPERVISOR_RESUME))
+
+      expect(resumed.error).toBeUndefined()
+      expect((resumed.result as { woken?: number }).woken).toBe(1)
+      expect(pingAgent.trigger).toHaveBeenCalledTimes(1)
+    })
+
+    it('wakes idle on-demand agents with runnable assigned work and no pending messages on resume', async () => {
+      const pingAgent = {
+        definition: { lifecycle: 'on-demand' },
+        state: 'running',
+        pause: vi.fn(),
+        resume: vi.fn(),
+        trigger: vi.fn().mockResolvedValue(undefined),
+      }
+      ;(supervisor as unknown as { agents: Map<string, unknown> }).agents.set('ping', pingAgent)
+
+      const taskRes = await supervisor.handleRpcAsync(rpc(RPC_METHODS.TASK_CREATE, {
+        title: 'Runnable task',
+        description: 'already assigned before resume',
+        assignee: 'ping',
+      }))
+      expect(taskRes.error).toBeUndefined()
+      expect(pingAgent.trigger).not.toHaveBeenCalled()
+
+      const drained = await supervisor.handleRpcAsync(rpc(RPC_METHODS.AGENT_RECV, {
+        agent: 'ping',
+      }))
+      expect(drained.error).toBeUndefined()
+      expect((drained.result as { messages: unknown[] }).messages.length).toBe(1)
+
+      pingAgent.state = 'idle'
+      const resumed = await supervisor.handleRpcAsync(rpc(RPC_METHODS.SUPERVISOR_RESUME))
+
+      expect(resumed.error).toBeUndefined()
+      expect((resumed.result as { woken?: number }).woken).toBe(1)
+      expect(pingAgent.trigger).toHaveBeenCalledTimes(1)
     })
 
     it('builds preamble/env providers from active skill snapshots and records run feedback', async () => {

--- a/packages/runtime/src/agent-process.ts
+++ b/packages/runtime/src/agent-process.ts
@@ -393,17 +393,26 @@ export class AgentProcess {
     this._state = 'running';
     this.currentUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     const pending = await resolveMaybePromise(this.relay.recv(this.definition.name, 10));
-    if (pending.length === 0) {
+    const hasRunnableWork = pending.length === 0
+      && this.hasAutonomousWork
+      && this.hasAutonomousWork(this.definition.name);
+    if (pending.length === 0 && !hasRunnableWork) {
       this.setIdleIfActive();
       log.info('no pending messages, skipping trigger', { agent: this.definition.name });
       return;
     }
 
-    const msgs = pending.map(m => {
-      const text = typeof m.payload === 'string' ? m.payload : JSON.stringify(m.payload);
-      return `[${m.priority}/${m.type}] ${m.from}: ${text}`;
-    }).join('\n');
-    let prompt = `You have been triggered. You have ${pending.length} pending message(s):\n\n${msgs}\n\nProcess these messages. Your task is complete once done.`;
+    let prompt: string;
+    if (pending.length > 0) {
+      const msgs = pending.map(m => {
+        const text = typeof m.payload === 'string' ? m.payload : JSON.stringify(m.payload);
+        return `[${m.priority}/${m.type}] ${m.from}: ${text}`;
+      }).join('\n');
+      prompt = `You have been triggered. You have ${pending.length} pending message(s):\n\n${msgs}\n\nProcess these messages. Your task is complete once done.`;
+    } else {
+      prompt = 'You have been triggered to continue runnable assigned work. Run `wanman task list --assignee ' +
+        `${this.definition.name}\` to inspect current tasks, then continue the highest-priority unblocked task.`;
+    }
 
     // Inject preamble context
     const preamble = this.preambleProvider

--- a/packages/runtime/src/supervisor.ts
+++ b/packages/runtime/src/supervisor.ts
@@ -654,32 +654,7 @@ ${activePaths}`;
 
       // Wake on-demand / idle_cached agents when any message arrives (not just steer)
       this.relay.setNewMessageCallback((agentName) => {
-        const agent = this.agents.get(agentName);
-        if (
-          agent
-          && (agent.definition.lifecycle === 'on-demand' || agent.definition.lifecycle === 'idle_cached')
-          && agent.state === 'idle'
-        ) {
-          // Check if any assigned task for this agent has unmet dependencies
-          const blocked = this.hasBlockedTasksOnly(agentName);
-          if (blocked) {
-            log.info('idle agent has only blocked tasks, deferring', {
-              agent: agentName,
-              lifecycle: agent.definition.lifecycle,
-            });
-            return;
-          }
-          log.info('waking idle agent for new message', {
-            agent: agentName,
-            lifecycle: agent.definition.lifecycle,
-          });
-          void agent.trigger().catch((err) => {
-            log.error('agent trigger failed', {
-              agent: agentName,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
-        }
+        this.wakeIdleAgentForPendingWork(agentName, 'new_message');
       });
     }
   }
@@ -822,6 +797,8 @@ ${activePaths}`;
         });
       });
     }
+
+    this.wakeIdleAgentsForPendingWork('startup');
 
     log.info('supervisor started', {
       agents: this.config.agents.map(a => a.name),
@@ -1687,11 +1664,13 @@ ${activePaths}`;
       }
 
       case RPC_METHODS.SUPERVISOR_RESUME: {
+        let woken = 0;
         for (const [name, agent] of this.agents) {
           agent.resume();
           log.info('resumed agent', { agent: name });
+          if (this.wakeIdleAgentForPendingWork(name, 'resume')) woken++;
         }
-        return createRpcResponse(req.id, { status: 'running', agents: this.agents.size });
+        return createRpcResponse(req.id, { status: 'running', agents: this.agents.size, woken });
       }
 
       default:
@@ -1738,6 +1717,62 @@ ${activePaths}`;
     } catch (err) {
       log.warn('wakeUnblockedAgents failed', { error: err instanceof Error ? err.message : String(err) });
     }
+  }
+
+  private wakeIdleAgentsForPendingWork(reason: string): number {
+    let woken = 0;
+    for (const name of this.agents.keys()) {
+      if (this.wakeIdleAgentForPendingWork(name, reason)) woken++;
+    }
+    return woken;
+  }
+
+  private wakeIdleAgentForPendingWork(agentName: string, reason: string): boolean {
+    const agent = this.agents.get(agentName);
+    if (
+      !agent
+      || !(agent.definition.lifecycle === 'on-demand' || agent.definition.lifecycle === 'idle_cached')
+      || agent.state !== 'idle'
+    ) {
+      return false;
+    }
+
+    let pendingCount = 0;
+    try {
+      pendingCount = this.relay.countPending(agentName);
+    } catch (err) {
+      log.warn('pending message count failed', {
+        agent: agentName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const hasRunnableWork = pendingCount > 0 || this.hasAutonomousWork(agentName);
+    if (!hasRunnableWork) return false;
+
+    if (this.hasBlockedTasksOnly(agentName)) {
+      log.info('idle agent has only blocked tasks, deferring', {
+        agent: agentName,
+        lifecycle: agent.definition.lifecycle,
+        reason,
+        pendingCount,
+      });
+      return false;
+    }
+
+    log.info('waking idle agent for pending work', {
+      agent: agentName,
+      lifecycle: agent.definition.lifecycle,
+      reason,
+      pendingCount,
+    });
+    void agent.trigger().catch((err) => {
+      log.error('agent trigger failed', {
+        agent: agentName,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+    return true;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Replays wakeups for idle `on-demand` / `idle_cached` agents on supervisor startup and `supervisor.resume` when pending messages or runnable assigned tasks already exist.
- Keeps the existing blocked-task guard when deciding whether to wake idle agents.
- Allows an explicit `AgentProcess.trigger()` to continue runnable assigned work even when the original task notification has already been consumed.

Fixes #21

## Tests
- `corepack pnpm --filter @wanman/runtime test -- src/__tests__/supervisor.test.ts src/__tests__/agent-process.test.ts`
- `corepack pnpm --filter @wanman/runtime typecheck`

I also attempted the full runtime test suite; unrelated tests that write to the system temp directory failed in this environment before exercising this change.