### PR TITLE
docs: align takeover workflow and coverage guidance

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -45,9 +45,13 @@ pnpm --filter @wanman/cli standalone
 node packages/cli/dist/wanman.mjs takeover /path/to/any/git/repo
 ```
 
+`pnpm build` は workspace の各パッケージをビルドし、通常の CLI エントリポイント `packages/cli/dist/index.js` を生成します。上記の単一ファイル bundle は `pnpm --filter @wanman/cli standalone` を実行したときだけ生成されます。
+
 `wanman` がすでに `PATH` にある場合は、対象リポジトリ内で `wanman takeover .` を直接実行できます。
 
 完全な手順は [`docs/quickstart.ja.md`](docs/quickstart.ja.md) を参照してください。
+
+takeover モードでは、作業は task 単位の capsule と `wanman/<task-slug>` ブランチで進みます。Dev エージェントは coverage メモ付きの PR を作成し、CTO の review gate は変更対象ファイルで 95% 以上の coverage です。
 
 ## CLI コマンド
 
@@ -136,7 +140,7 @@ pnpm test
 pnpm exec vitest run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.exclude='**/dist/**'
 ```
 
-現在のカバレッジ目標は、行カバレッジ 90% 以上です。直近のローカル検証では `Lines: 90.17%` でした。機械可読のサマリーは `coverage/coverage-summary.json` に出力されます。
+takeover 作業では、上記コマンドの coverage サマリーを PR 本文に添付してください。現在の merge gate は変更対象ファイルで 95% 以上の coverage で、機械可読のリポジトリ全体サマリーは `coverage/coverage-summary.json` に出力されます。
 
 ## プロジェクト構造
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,13 @@ pnpm --filter @wanman/cli standalone
 node packages/cli/dist/wanman.mjs takeover /path/to/any/git/repo
 ```
 
+`pnpm build` compiles the workspace packages and the regular CLI entrypoint at `packages/cli/dist/index.js`. The optional single-file bundle above is produced only by `pnpm --filter @wanman/cli standalone`.
+
 If `wanman` is already on your `PATH`, you can also run `wanman takeover .` from inside the target repository.
 
 See [`docs/quickstart.md`](docs/quickstart.md) for the full walkthrough.
+
+In takeover mode, work is expected to move through task-scoped capsules and `wanman/<task-slug>` branches. Dev agents open PRs with coverage notes, and the CTO review gate is at least 95% coverage on changed files.
 
 For cost and revenue accounting, see [`docs/finops.md`](docs/finops.md). The local FinOps review app runs with `pnpm --filter @wanman/finops dev -- --host 127.0.0.1 --port 4173`.
 
@@ -139,7 +143,7 @@ pnpm test
 pnpm exec vitest run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.exclude='**/dist/**'
 ```
 
-The current coverage target is at least 90% line coverage. The latest verified local run reports `Lines: 90.17%`; the machine-readable summary is written to `coverage/coverage-summary.json`.
+For takeover work, attach coverage from the command above to the PR body. The current merge gate is at least 95% coverage on changed files, and the machine-readable repo-wide summary is written to `coverage/coverage-summary.json`.
 
 ## Project structure
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -45,9 +45,13 @@ pnpm --filter @wanman/cli standalone
 node packages/cli/dist/wanman.mjs takeover /path/to/any/git/repo
 ```
 
+`pnpm build` 会编译整个 workspace，并生成常规 CLI 入口 `packages/cli/dist/index.js`。上面的单文件 bundle 只会在执行 `pnpm --filter @wanman/cli standalone` 时生成。
+
 如果 `wanman` 已经在你的 `PATH` 中，也可以在目标仓库内直接运行 `wanman takeover .`。
 
 完整流程见 [`docs/quickstart.zh.md`](docs/quickstart.zh.md)。
+
+在 takeover 模式下，工作会通过按 task 划分的 capsule 和 `wanman/<task-slug>` 分支推进。Dev agent 需要提交带 coverage 说明的 PR，而 CTO 的 review gate 是变更文件 coverage 至少 95%。
 
 ## CLI 命令
 
@@ -136,7 +140,7 @@ pnpm test
 pnpm exec vitest run --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.exclude='**/dist/**'
 ```
 
-当前覆盖率目标是行覆盖率至少 90%。最新一次本地验证结果为 `Lines: 90.17%`；机器可读的汇总会写入 `coverage/coverage-summary.json`。
+对于 takeover 工作，请把上面命令产出的 coverage 摘要贴进 PR 正文。当前的 merge gate 是变更文件 coverage 至少 95%，而机器可读的全仓汇总会写入 `coverage/coverage-summary.json`。
 
 ## 项目结构
 

--- a/docs/quickstart.ja.md
+++ b/docs/quickstart.ja.md
@@ -25,7 +25,7 @@ pnpm install
 pnpm build
 ```
 
-`pnpm build` は `packages/cli/dist/index.js` に独立した CLI バンドルを生成します。`PATH` に追加するか、開発中は `pnpm --filter @wanman/cli exec wanman ...` を使ってください。
+`pnpm build` は workspace の各パッケージをビルドし、CLI のエントリポイント `packages/cli/dist/index.js` を生成します。ソース開発中は `pnpm --filter @wanman/cli exec wanman ...` を使い、単一ファイル bundle が必要な場合だけ `pnpm --filter @wanman/cli standalone` で `packages/cli/dist/wanman.mjs` を生成してください。
 
 ローカルでの反復開発には CLI を `npm link` しておくと便利です:
 
@@ -80,7 +80,16 @@ wanman send ceo --steer "Stop — focus on the API, not the landing page"
 wanman recv --agent ceo
 ```
 
-## 5. artifact を確認する
+## 5. takeover のデリバリーループを把握する
+
+matrix の起動後、ローカル takeover の標準ワークフローは次のとおりです:
+
+1. CEO が目標を task と change capsule に分解します。
+2. Dev エージェントは `wanman/<task-slug>` ブランチでスコープ内の変更を行い、coverage メモ付きの PR を作成します。
+3. PR 本文または CI が変更対象ファイルで 95% 以上の coverage を示したときだけ、CTO が review を開始します。
+4. 承認後に PR がマージされ、task と capsule の状態は `.wanman/` に記録され続けます。
+
+## 6. artifact を確認する
 
 エージェントは `wanman artifact put` を通じて、構造化された artifact — 調査サマリ、計画、財務モデルなど — を生成します。これらを閲覧するには:
 
@@ -100,7 +109,7 @@ wanman task get <task-id>
 wanman initiative list
 ```
 
-## 6. クリーンアップ
+## 7. クリーンアップ
 
 takeover のために wanman が作成するものはすべて、対象リポジトリ内の `.wanman/` 配下にあります:
 
@@ -121,7 +130,7 @@ rm -rf .wanman
 
 あなたの実際の作業ツリーには一切触れていません — wanman は `.wanman/` の内部にしか書き込んでいません。
 
-## 7. 次のステップ
+## 8. 次のステップ
 
 - JSON-RPC プロトコル、メッセージ優先度、エージェントのライフサイクルを理解したい場合は [architecture.ja.md](architecture.ja.md) を参照してください。
 - 貢献したい場合は [CONTRIBUTING.ja.md](../CONTRIBUTING.ja.md) を参照してください。

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -25,7 +25,7 @@ pnpm install
 pnpm build
 ```
 
-`pnpm build` produces a standalone CLI bundle at `packages/cli/dist/index.js`. Either add it to your `PATH` or use `pnpm --filter @wanman/cli exec wanman ...` during development.
+`pnpm build` compiles the workspace packages and emits the CLI entrypoint at `packages/cli/dist/index.js`. During source development, use `pnpm --filter @wanman/cli exec wanman ...`; if you need the single-file bundle, run `pnpm --filter @wanman/cli standalone` to produce `packages/cli/dist/wanman.mjs`.
 
 For local iteration you can `npm link` the CLI:
 
@@ -80,7 +80,16 @@ To read the replies (and mark them delivered):
 wanman recv --agent ceo
 ```
 
-## 5. Inspect artifacts
+## 5. Follow the takeover delivery loop
+
+Once the matrix is running, the default local takeover workflow is:
+
+1. The CEO decomposes goals into tasks and change capsules.
+2. Dev agents make scoped changes on a `wanman/<task-slug>` branch, then push a PR with coverage notes.
+3. The CTO reviews only after the PR body or CI shows at least 95% coverage on changed files.
+4. After approval, the PR merges and the task/capsule state is updated inside `.wanman/`.
+
+## 6. Inspect artifacts
 
 Agents produce structured artifacts — research summaries, plans, financial models, etc. — through `wanman artifact put`. To browse them:
 
@@ -100,7 +109,7 @@ wanman task get <task-id>
 wanman initiative list
 ```
 
-## 6. Cleanup
+## 7. Cleanup
 
 Everything wanman creates for a takeover lives under `.wanman/` inside the target repo:
 
@@ -121,7 +130,7 @@ rm -rf .wanman
 
 Your real working tree is untouched — wanman only ever wrote inside `.wanman/`.
 
-## 7. Where next
+## 8. Where next
 
 - Want to understand the JSON-RPC protocol, message priorities, and agent lifecycles? See [architecture.md](architecture.md).
 - Want to contribute? See [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/quickstart.zh.md
+++ b/docs/quickstart.zh.md
@@ -25,7 +25,7 @@ pnpm install
 pnpm build
 ```
 
-`pnpm build` 会在 `packages/cli/dist/index.js` 产出一个独立的 CLI bundle。你可以把它加入 `PATH`，或者在开发中直接用 `pnpm --filter @wanman/cli exec wanman ...`。
+`pnpm build` 会编译整个 workspace，并生成 CLI 入口 `packages/cli/dist/index.js`。在源码开发阶段，用 `pnpm --filter @wanman/cli exec wanman ...` 直接运行；如果需要单文件 bundle，再执行 `pnpm --filter @wanman/cli standalone` 生成 `packages/cli/dist/wanman.mjs`。
 
 本地迭代时可以用 `npm link` 链接该 CLI：
 
@@ -80,7 +80,16 @@ wanman send ceo --steer "Stop — focus on the API, not the landing page"
 wanman recv --agent ceo
 ```
 
-## 5. 查看 artifact
+## 5. 了解 takeover 交付循环
+
+matrix 跑起来后，默认的本地 takeover 工作流是：
+
+1. CEO 把目标拆成 task 和 change capsule。
+2. Dev agent 在 `wanman/<task-slug>` 分支上做范围受控的修改，并提交带 coverage 说明的 PR。
+3. 只有当 PR 正文或 CI 显示变更文件的 coverage 至少达到 95% 时，CTO 才会开始 review。
+4. PR 通过后合并，task 和 capsule 的状态继续记录在 `.wanman/` 中。
+
+## 6. 查看 artifact
 
 Agent 通过 `wanman artifact put` 产出结构化的 artifact —— 调研摘要、计划、财务模型等。浏览它们：
 
@@ -100,7 +109,7 @@ wanman task get <task-id>
 wanman initiative list
 ```
 
-## 6. 清理
+## 7. 清理
 
 wanman 为一次 takeover 所创建的一切都放在目标仓库内的 `.wanman/` 下：
 
@@ -121,7 +130,7 @@ rm -rf .wanman
 
 你真实的工作区毫发无损 —— wanman 只在 `.wanman/` 里写过东西。
 
-## 7. 接下来去哪里
+## 8. 接下来去哪里
 
 - 想理解 JSON-RPC 协议、消息优先级和 agent 生命周期？见 [architecture.zh.md](architecture.zh.md)。
 - 想贡献代码？见 [CONTRIBUTING.zh.md](../CONTRIBUTING.zh.md)。


### PR DESCRIPTION
## Summary
- fix README and quickstart guidance across English, Chinese, and Japanese to distinguish pnpm build from the optional standalone bundle build
- document the current takeover delivery loop: task-scoped capsules, wanman/<task-slug> branches, PR handoff, and CTO review responsibilities
- replace the stale repo-wide 90.17% coverage claim with the current changed-file >=95% PR gate and keep coverage/coverage-summary.json as the machine-readable summary location

## Verification
- git diff --check

## Test Coverage
- Docs-only change; no executable files changed, so coverage is not applicable for this diff
