### PR TITLE
fix(runtime): harden Windows host adapter defaults

### DIFF
--- a/packages/runtime/src/__tests__/agent-home-manager.test.ts
+++ b/packages/runtime/src/__tests__/agent-home-manager.test.ts
@@ -1,13 +1,14 @@
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AgentHomeManager } from '../agent-home-manager.js'
 
 const tempRoots: string[] = []
 
 describe('AgentHomeManager', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     for (const root of tempRoots.splice(0)) {
       fs.rmSync(root, { recursive: true, force: true })
     }
@@ -45,6 +46,18 @@ describe('AgentHomeManager', () => {
     expect(fs.readdirSync(claudeSkills)).toHaveLength(0)
   })
 
+  it('skips missing runtime roots while preparing the agent home', () => {
+    const { baseHome, homesRoot } = createFixture()
+    fs.rmSync(path.join(baseHome, '.codex'), { recursive: true, force: true })
+    const manager = new AgentHomeManager(baseHome, homesRoot)
+
+    const agentHome = manager.prepareAgentHome('partial-runtime')
+
+    expect(fs.existsSync(path.join(agentHome, '.claude', '.credentials.json'))).toBe(true)
+    expect(fs.existsSync(path.join(agentHome, '.codex', 'config.json'))).toBe(false)
+    expect(fs.lstatSync(path.join(agentHome, '.codex', 'skills')).isSymbolicLink()).toBe(true)
+  })
+
   it('cleans up all prepared homes', () => {
     const { baseHome, homesRoot } = createFixture()
     const manager = new AgentHomeManager(baseHome, homesRoot)
@@ -54,6 +67,113 @@ describe('AgentHomeManager', () => {
 
     manager.cleanupHomes()
     expect(fs.existsSync(homesRoot)).toBe(false)
+  })
+
+  it('falls back to junction links for directories when Windows symlink privileges are missing', () => {
+    const { baseHome, homesRoot, snapshotPath } = createFixture()
+    const manager = new AgentHomeManager(baseHome, homesRoot)
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const originalSymlinkSync = fs.symlinkSync.bind(fs)
+    const symlinkSpy = vi.spyOn(fs, 'symlinkSync').mockImplementation((target, path, type) => {
+      if (type === 'dir') {
+        const error = Object.assign(new Error('missing symlink privilege'), { code: 'EPERM' })
+        throw error
+      }
+      return originalSymlinkSync(target, path, type)
+    })
+
+    manager.prepareAgentHome('windows', {
+      id: 'snapshot-2',
+      runId: 'run-2',
+      agent: 'windows',
+      activationScope: 'task',
+      materializedPath: snapshotPath,
+      resolvedSkills: [],
+    })
+
+    expect(symlinkSpy.mock.calls.some(([, , type]) => type === 'junction')).toBe(true)
+    platformSpy.mockRestore()
+  })
+
+  it('throws actionable guidance when Windows file symlinks are blocked', () => {
+    const { baseHome, homesRoot } = createFixture()
+    const manager = new AgentHomeManager(baseHome, homesRoot)
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const originalSymlinkSync = fs.symlinkSync.bind(fs)
+    vi.spyOn(fs, 'symlinkSync').mockImplementation((target, path, type) => {
+      if (type === 'file') {
+        const error = Object.assign(new Error('missing symlink privilege'), { code: 'EACCES' })
+        throw error
+      }
+      return originalSymlinkSync(target, path, type)
+    })
+
+    expect(() => manager.prepareAgentHome('windows-file')).toThrow(
+      /Enable Windows Developer Mode or run wanman inside WSL2 or Linux\/macOS/,
+    )
+
+    platformSpy.mockRestore()
+  })
+
+  it('rethrows file link errors outside Windows privilege handling', () => {
+    const { baseHome, homesRoot } = createFixture()
+    const manager = new AgentHomeManager(baseHome, homesRoot)
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    const originalSymlinkSync = fs.symlinkSync.bind(fs)
+    const expected = new Error('file symlink failed')
+    vi.spyOn(fs, 'symlinkSync').mockImplementation((target, linkPath, type) => {
+      if (type === 'file' && String(linkPath).endsWith('.npmrc')) {
+        throw expected
+      }
+      return originalSymlinkSync(target, linkPath, type)
+    })
+
+    expect(() => manager.prepareAgentHome('linux-file')).toThrow(expected)
+
+    platformSpy.mockRestore()
+  })
+
+  it('rethrows directory link errors outside Windows privilege handling', () => {
+    const { baseHome, homesRoot } = createFixture()
+    const manager = new AgentHomeManager(baseHome, homesRoot)
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    const originalSymlinkSync = fs.symlinkSync.bind(fs)
+    const expected = new Error('dir symlink failed')
+    vi.spyOn(fs, 'symlinkSync').mockImplementation((target, linkPath, type) => {
+      if (type === 'dir' && String(linkPath).endsWith('.config')) {
+        throw expected
+      }
+      return originalSymlinkSync(target, linkPath, type)
+    })
+
+    expect(() => manager.prepareAgentHome('linux-dir')).toThrow(expected)
+
+    platformSpy.mockRestore()
+  })
+
+  it('rethrows skills link errors outside Windows privilege handling', () => {
+    const { baseHome, homesRoot, snapshotPath } = createFixture()
+    const manager = new AgentHomeManager(baseHome, homesRoot)
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    const originalSymlinkSync = fs.symlinkSync.bind(fs)
+    const expected = new Error('skills symlink failed')
+    vi.spyOn(fs, 'symlinkSync').mockImplementation((target, linkPath, type) => {
+      if (type === 'dir' && String(linkPath).endsWith(`${path.sep}skills`)) {
+        throw expected
+      }
+      return originalSymlinkSync(target, linkPath, type)
+    })
+
+    expect(() => manager.prepareAgentHome('linux-skills', {
+      id: 'snapshot-3',
+      runId: 'run-3',
+      agent: 'linux-skills',
+      activationScope: 'task',
+      materializedPath: snapshotPath,
+      resolvedSkills: [],
+    })).toThrow(expected)
+
+    platformSpy.mockRestore()
   })
 })
 

--- a/packages/runtime/src/__tests__/claude-code.test.ts
+++ b/packages/runtime/src/__tests__/claude-code.test.ts
@@ -322,6 +322,27 @@ describe('spawnClaudeCode', () => {
     expect(args).not.toContain('--resume')
   })
 
+  it('should preserve the existing shell on Windows', () => {
+    const previousShell = process.env.SHELL
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    process.env.SHELL = 'C:\\Windows\\System32\\cmd.exe'
+
+    spawnClaudeCode({
+      model: 'haiku',
+      systemPrompt: 'test',
+      cwd: '/tmp',
+    })
+
+    const calls = (spawnMock as unknown as { mock: { calls: unknown[][] } }).mock.calls
+    const options = calls[calls.length - 1]![2] as { env: Record<string, string | undefined> }
+    expect(options.env.SHELL).toBe('C:\\Windows\\System32\\cmd.exe')
+    expect(options.env.SHELL).not.toBe('/bin/bash')
+
+    platformSpy.mockRestore()
+    if (previousShell === undefined) delete process.env.SHELL
+    else process.env.SHELL = previousShell
+  })
+
   it('should pass --resume <id> when resumeSessionId is set', () => {
     spawnClaudeCode({
       model: 'haiku',

--- a/packages/runtime/src/__tests__/codex-adapter.test.ts
+++ b/packages/runtime/src/__tests__/codex-adapter.test.ts
@@ -135,26 +135,57 @@ describe('spawnCodexExec', () => {
   });
 
   it('uses runuser when a root supervisor runs an agent as another user', () => {
-    const getuid = process.getuid ? vi.spyOn(process, 'getuid').mockReturnValue(0) : undefined;
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'getuid');
+    Object.defineProperty(process, 'getuid', {
+      value: vi.fn(() => 0),
+      configurable: true,
+    });
     const proc = createMockProc();
     spawnMock.mockReturnValue(proc);
+
+    try {
+      spawnCodexExec({
+        runtime: 'codex',
+        model: 'gpt-5.4',
+        systemPrompt: 'System prompt',
+        cwd: '/tmp/work',
+        runAsUser: 'agent',
+      });
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'runuser',
+        expect.arrayContaining(['-u', 'agent', '--', 'codex']),
+        expect.objectContaining({
+          env: expect.objectContaining({ HOME: '/home/agent' }),
+        }),
+      );
+    } finally {
+      if (descriptor) Object.defineProperty(process, 'getuid', descriptor);
+      else delete (process as NodeJS.Process & { getuid?: () => number }).getuid;
+    }
+  });
+
+  it('preserves the existing shell on Windows', () => {
+    const proc = createMockProc();
+    spawnMock.mockReturnValue(proc);
+    const previousShell = process.env['SHELL'];
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    process.env['SHELL'] = 'C:\\Windows\\System32\\cmd.exe';
 
     spawnCodexExec({
       runtime: 'codex',
       model: 'gpt-5.4',
       systemPrompt: 'System prompt',
       cwd: '/tmp/work',
-      runAsUser: 'agent',
     });
 
-    expect(spawnMock).toHaveBeenCalledWith(
-      'runuser',
-      expect.arrayContaining(['-u', 'agent', '--', 'codex']),
-      expect.objectContaining({
-        env: expect.objectContaining({ HOME: '/home/agent' }),
-      }),
-    );
-    getuid?.mockRestore();
+    const options = spawnMock.mock.calls[0]![2] as { env: Record<string, string | undefined> };
+    expect(options.env.SHELL).toBe('C:\\Windows\\System32\\cmd.exe');
+    expect(options.env.SHELL).not.toBe('/bin/bash');
+
+    platformSpy.mockRestore();
+    if (previousShell === undefined) delete process.env['SHELL'];
+    else process.env['SHELL'] = previousShell;
   });
 
   it('passes fast mode through as service_tier and fast_mode config overrides', () => {

--- a/packages/runtime/src/agent-home-manager.ts
+++ b/packages/runtime/src/agent-home-manager.ts
@@ -15,6 +15,19 @@ const DEFAULT_HOME_ENTRIES = [
   '.kube',
 ] as const
 
+function isWindowsLinkPrivilegeError(error: unknown): error is NodeJS.ErrnoException {
+  if (!error || typeof error !== 'object') return false
+  const code = (error as NodeJS.ErrnoException).code
+  return code === 'EPERM' || code === 'EACCES'
+}
+
+function windowsLinkGuidance(target: string): Error {
+  return new Error(
+    `wanman runtime could not prepare the Windows agent home link at ${target}. `
+    + 'Enable Windows Developer Mode or run wanman inside WSL2 or Linux/macOS.',
+  )
+}
+
 export class AgentHomeManager {
   private baseHome: string
   private homesRoot: string
@@ -73,12 +86,40 @@ export class AgentHomeManager {
     if (!fs.existsSync(source)) return
     fs.rmSync(target, { recursive: true, force: true })
     const stat = fs.statSync(source)
-    fs.symlinkSync(source, target, stat.isDirectory() ? 'dir' : 'file')
+    if (!stat.isDirectory()) {
+      try {
+        fs.symlinkSync(source, target, 'file')
+      } catch (error) {
+        if (process.platform === 'win32' && isWindowsLinkPrivilegeError(error)) {
+          throw windowsLinkGuidance(target)
+        }
+        throw error
+      }
+      return
+    }
+
+    try {
+      fs.symlinkSync(source, target, 'dir')
+    } catch (error) {
+      if (process.platform === 'win32' && isWindowsLinkPrivilegeError(error)) {
+        fs.symlinkSync(source, target, 'junction')
+        return
+      }
+      throw error
+    }
   }
 
   private linkSkillsDir(target: string, source: string): void {
     fs.rmSync(target, { recursive: true, force: true })
-    fs.symlinkSync(source, target, 'dir')
+    try {
+      fs.symlinkSync(source, target, 'dir')
+    } catch (error) {
+      if (process.platform === 'win32' && isWindowsLinkPrivilegeError(error)) {
+        fs.symlinkSync(source, target, 'junction')
+        return
+      }
+      throw error
+    }
   }
 
   private ensureEmptySkillsDir(agentHome: string): string {

--- a/packages/runtime/src/claude-code.ts
+++ b/packages/runtime/src/claude-code.ts
@@ -160,7 +160,7 @@ export function spawnClaudeCode(opts: SpawnOptions): ClaudeCodeProcess {
     env: {
       ...process.env,
       // Force bash shell — prevents zsh glob expansion breaking paths like (auth)/
-      SHELL: '/bin/bash',
+      ...(process.platform === 'win32' ? {} : { SHELL: '/bin/bash' }),
       // Fix HOME for runuser: Claude Code needs correct home for session-env, settings, etc.
       ...(useRunuser ? { HOME: `/home/${runAsUser}` } : {}),
       DISABLE_AUTOUPDATER: '1',

--- a/packages/runtime/src/codex-adapter.ts
+++ b/packages/runtime/src/codex-adapter.ts
@@ -112,7 +112,7 @@ export function spawnCodexExec(opts: AgentRunOptions): AgentRunHandle {
     cwd: opts.cwd,
     env: {
       ...process.env,
-      SHELL: '/bin/bash',
+      ...(process.platform === 'win32' ? {} : { SHELL: '/bin/bash' }),
       ...(useRunuser ? { HOME: `/home/${runAsUser}` } : {}),
       DISABLE_AUTOUPDATER: '1',
       DISABLE_TELEMETRY: '1',


### PR DESCRIPTION
## Summary
- stop forcing `SHELL=/bin/bash` inside the Claude and Codex runtime adapters when the host platform is Windows
- fall back to Windows `junction` links for isolated agent-home directories when normal directory symlinks are blocked
- throw actionable guidance when Windows blocks the remaining required file symlinks
- harden runtime adapter coverage for Windows shell preservation, runuser expectations, and agent-home link fallback behavior

## Verification
- `[pass]` `pnpm --filter @wanman/runtime exec vitest run src/__tests__/agent-home-manager.test.ts src/__tests__/claude-code.test.ts src/__tests__/codex-adapter.test.ts --coverage --coverage.reporter=text-summary --coverage.reporter=json-summary --coverage.include=src/agent-home-manager.ts --coverage.include=src/claude-code.ts --coverage.include=src/codex-adapter.ts`
- `53` focused runtime tests passed
- Included-file coverage: `Lines 96.17% (226/235)`, `Statements 93.33% (252/270)`, `Branches 79.5% (159/200)`, `Functions 89.58% (43/48)`

## Coverage Notes
- `packages/runtime/src/agent-home-manager.ts`: `100%` line coverage
- `packages/runtime/src/claude-code.ts`: `94.44%` line coverage
- `packages/runtime/src/codex-adapter.ts`: `95.65%` line coverage
- Combined included-file line coverage across the changed runtime surfaces: `96.17%`

Task: `663cbe75`
Capsule: `37713a09`
