### PR TITLE
Protect local takeover restarts from discarding in-flight work

### DIFF
--- a/packages/cli/src/takeover-local.test.ts
+++ b/packages/cli/src/takeover-local.test.ts
@@ -10,6 +10,7 @@ import {
   buildPrNudgeSignature,
   collectPrNudgeRecipients,
   hasLocalProgress,
+  isReusableLocalWorktree,
   materializeLocalTakeoverProject,
   maybeNudgeLocalPrExecution,
   parseLocalGitStatus,
@@ -264,8 +265,290 @@ describe('materializeLocalTakeoverProject', () => {
     expect(agentsConfig.agents[0]?.model).toBe('high')
     expect(fs.readFileSync(path.join(wanmanDir, 'skills', 'takeover-context', 'SKILL.md'), 'utf-8')).toContain('Ship project')
   })
+
+  it('reuses an existing takeover worktree so restart does not discard in-flight changes', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    const profile: ProjectProfile = {
+      path: repo,
+      languages: ['typescript'],
+      packageManagers: [],
+      frameworks: [],
+      ci: [],
+      testFrameworks: [],
+      hasReadme: true,
+      hasClaudeMd: false,
+      hasDocs: false,
+      issueTracker: 'none',
+      readmeExcerpt: 'App',
+      codeRoots: ['src'],
+      packageScripts: ['test'],
+    }
+    const generated: GeneratedAgentConfig = {
+      runtime: 'codex',
+      goal: 'Ship project',
+      intent: {
+        projectName: 'app',
+        summary: 'Ship project',
+        canonicalDocs: [],
+        roadmapDocs: [],
+        codeRoots: ['src'],
+        packageScripts: ['test'],
+        strategicThemes: ['quality'],
+        mission: 'Ship project',
+      },
+      agents: [],
+    }
+
+    const wanmanDir = materializeLocalTakeoverProject(profile, generated)
+    const worktreeReadme = path.join(wanmanDir, 'worktree', 'README.md')
+    fs.writeFileSync(worktreeReadme, '# Agent WIP\n')
+
+    materializeLocalTakeoverProject(profile, generated)
+
+    expect(fs.readFileSync(worktreeReadme, 'utf-8')).toBe('# Agent WIP\n')
+    expect(execGit(path.join(wanmanDir, 'worktree'), 'status --short README.md')).toContain('M README.md')
+  })
+
+  it('blocks takeover restart before deleting a non-reusable worktree directory', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    const profile: ProjectProfile = {
+      path: repo,
+      languages: ['typescript'],
+      packageManagers: [],
+      frameworks: [],
+      ci: [],
+      testFrameworks: [],
+      hasReadme: true,
+      hasClaudeMd: false,
+      hasDocs: false,
+      issueTracker: 'none',
+      readmeExcerpt: 'App',
+      codeRoots: ['src'],
+      packageScripts: ['test'],
+    }
+    const generated: GeneratedAgentConfig = {
+      runtime: 'codex',
+      goal: 'Ship project',
+      intent: {
+        projectName: 'app',
+        summary: 'Ship project',
+        canonicalDocs: [],
+        roadmapDocs: [],
+        codeRoots: ['src'],
+        packageScripts: ['test'],
+        strategicThemes: ['quality'],
+        mission: 'Ship project',
+      },
+      agents: [],
+    }
+
+    const worktreePath = path.join(repo, '.wanman', 'worktree')
+    fs.mkdirSync(worktreePath, { recursive: true })
+    fs.writeFileSync(path.join(worktreePath, 'scratch.txt'), 'keep me')
+
+    expect(() => materializeLocalTakeoverProject(profile, generated)).toThrow(
+      /Refusing to recreate takeover worktree/,
+    )
+    expect(fs.readFileSync(path.join(worktreePath, 'scratch.txt'), 'utf-8')).toBe('keep me')
+  })
+
+  it('recreates an empty non-worktree directory before adding the takeover worktree', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    const profile: ProjectProfile = {
+      path: repo,
+      languages: ['typescript'],
+      packageManagers: [],
+      frameworks: [],
+      ci: [],
+      testFrameworks: [],
+      hasReadme: true,
+      hasClaudeMd: false,
+      hasDocs: false,
+      issueTracker: 'none',
+      readmeExcerpt: 'App',
+      codeRoots: ['src'],
+      packageScripts: ['test'],
+    }
+    const generated: GeneratedAgentConfig = {
+      runtime: 'codex',
+      goal: 'Ship project',
+      intent: {
+        projectName: 'app',
+        summary: 'Ship project',
+        canonicalDocs: [],
+        roadmapDocs: [],
+        codeRoots: ['src'],
+        packageScripts: ['test'],
+        strategicThemes: ['quality'],
+        mission: 'Ship project',
+      },
+      agents: [],
+    }
+
+    const worktreePath = path.join(repo, '.wanman', 'worktree')
+    fs.mkdirSync(worktreePath, { recursive: true })
+
+    materializeLocalTakeoverProject(profile, generated)
+
+    expect(path.normalize(execGit(worktreePath, 'rev-parse --show-toplevel'))).toBe(path.normalize(worktreePath))
+  })
+
+  it('blocks takeover restart before reusing a worktree from another git repository', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    const profile: ProjectProfile = {
+      path: repo,
+      languages: ['typescript'],
+      packageManagers: [],
+      frameworks: [],
+      ci: [],
+      testFrameworks: [],
+      hasReadme: true,
+      hasClaudeMd: false,
+      hasDocs: false,
+      issueTracker: 'none',
+      readmeExcerpt: 'App',
+      codeRoots: ['src'],
+      packageScripts: ['test'],
+    }
+    const generated: GeneratedAgentConfig = {
+      runtime: 'codex',
+      goal: 'Ship project',
+      intent: {
+        projectName: 'app',
+        summary: 'Ship project',
+        canonicalDocs: [],
+        roadmapDocs: [],
+        codeRoots: ['src'],
+        packageScripts: ['test'],
+        strategicThemes: ['quality'],
+        mission: 'Ship project',
+      },
+      agents: [],
+    }
+
+    const worktreePath = path.join(repo, '.wanman', 'worktree')
+    fs.mkdirSync(worktreePath, { recursive: true })
+    execGit(worktreePath, 'init')
+    fs.writeFileSync(path.join(worktreePath, 'foreign.txt'), 'do not reuse')
+
+    expect(() => materializeLocalTakeoverProject(profile, generated)).toThrow(
+      /Refusing to recreate takeover worktree/,
+    )
+    expect(fs.readFileSync(path.join(worktreePath, 'foreign.txt'), 'utf-8')).toBe('do not reuse')
+  })
+
+  it('blocks takeover restart when the existing worktree metadata is broken', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    const profile: ProjectProfile = {
+      path: repo,
+      languages: ['typescript'],
+      packageManagers: [],
+      frameworks: [],
+      ci: [],
+      testFrameworks: [],
+      hasReadme: true,
+      hasClaudeMd: false,
+      hasDocs: false,
+      issueTracker: 'none',
+      readmeExcerpt: 'App',
+      codeRoots: ['src'],
+      packageScripts: ['test'],
+    }
+    const generated: GeneratedAgentConfig = {
+      runtime: 'codex',
+      goal: 'Ship project',
+      intent: {
+        projectName: 'app',
+        summary: 'Ship project',
+        canonicalDocs: [],
+        roadmapDocs: [],
+        codeRoots: ['src'],
+        packageScripts: ['test'],
+        strategicThemes: ['quality'],
+        mission: 'Ship project',
+      },
+      agents: [],
+    }
+
+    const worktreePath = path.join(repo, '.wanman', 'worktree')
+    fs.mkdirSync(worktreePath, { recursive: true })
+    fs.writeFileSync(path.join(worktreePath, '.git'), 'gitdir: missing-worktree')
+    fs.writeFileSync(path.join(worktreePath, 'foreign.txt'), 'do not delete')
+
+    expect(() => materializeLocalTakeoverProject(profile, generated)).toThrow(
+      /Refusing to recreate takeover worktree/,
+    )
+    expect(fs.readFileSync(path.join(worktreePath, 'foreign.txt'), 'utf-8')).toBe('do not delete')
+  })
+
+  it('treats a missing takeover worktree path as non-reusable', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    expect(isReusableLocalWorktree(path.join(repo, '.wanman', 'worktree'), repo)).toBe(false)
+  })
+
+  it('treats a file at the takeover worktree path as non-reusable', () => {
+    const repo = makeTmpDir()
+    execGit(repo, 'init')
+    execGit(repo, 'config user.email test@example.com')
+    execGit(repo, 'config user.name Test')
+    fs.writeFileSync(path.join(repo, 'README.md'), '# App\n')
+    execGit(repo, 'add README.md')
+    execGit(repo, 'commit -m init')
+
+    const worktreePath = path.join(repo, '.wanman', 'worktree')
+    fs.mkdirSync(path.dirname(worktreePath), { recursive: true })
+    fs.writeFileSync(worktreePath, 'not a directory')
+
+    expect(isReusableLocalWorktree(worktreePath, repo)).toBe(false)
+  })
 })
 
-function execGit(cwd: string, args: string): void {
-  execSync(`git ${args}`, { cwd, stdio: 'ignore' })
+function execGit(cwd: string, args: string): string {
+  return execSync(`git ${args}`, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
 }

--- a/packages/cli/src/takeover-local.ts
+++ b/packages/cli/src/takeover-local.ts
@@ -440,6 +440,49 @@ export async function maybeNudgeLocalPrExecution(
   return true
 }
 
+function readGitCommonDir(repoPath: string): string | undefined {
+  try {
+    const gitCommonDir = execSync(`git -C ${JSON.stringify(repoPath)} rev-parse --path-format=absolute --git-common-dir`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+    if (!gitCommonDir) return undefined
+    const absolutePath = path.isAbsolute(gitCommonDir) ? gitCommonDir : path.resolve(repoPath, gitCommonDir)
+    return path.normalize(fs.realpathSync.native(absolutePath))
+  } catch {
+    return undefined
+  }
+}
+
+function readGitTopLevel(repoPath: string): string | undefined {
+  try {
+    const topLevel = execSync(`git -C ${JSON.stringify(repoPath)} rev-parse --show-toplevel`, {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim()
+    if (!topLevel) return undefined
+    return path.normalize(fs.realpathSync.native(topLevel))
+  } catch {
+    return undefined
+  }
+}
+
+/** @internal exported for testing */
+export function isReusableLocalWorktree(worktreePath: string, repoPath: string): boolean {
+  if (!fs.existsSync(worktreePath)) return false
+  const worktreeTopLevel = readGitTopLevel(worktreePath)
+  const worktreeCommonDir = readGitCommonDir(worktreePath)
+  const repoCommonDir = readGitCommonDir(repoPath)
+  const expectedWorktreePath = path.normalize(fs.realpathSync.native(worktreePath))
+  return (
+    !!worktreeTopLevel
+    && !!worktreeCommonDir
+    && !!repoCommonDir
+    && worktreeTopLevel === expectedWorktreePath
+    && worktreeCommonDir === repoCommonDir
+  )
+}
+
 export function materializeLocalTakeoverProject(
   profile: ProjectProfile,
   generated: GeneratedAgentConfig,
@@ -452,16 +495,37 @@ export function materializeLocalTakeoverProject(
     cwd: profile.path,
     stdio: 'pipe',
   })
-  const currentHead = execSync('git rev-parse --verify HEAD', {
-    cwd: profile.path,
-    encoding: 'utf-8',
-  }).trim()
-  fs.rmSync(worktreePath, { recursive: true, force: true })
-  execSync(`git worktree add --detach -f "${worktreePath}" ${currentHead}`, {
-    cwd: profile.path,
-    stdio: 'pipe',
-  })
-  console.log(`  [local] Created git worktree at ${worktreePath}`)
+
+  let createdWorktree = false
+  if (fs.existsSync(worktreePath)) {
+    if (isReusableLocalWorktree(worktreePath, profile.path)) {
+      console.log(`  [local] Reusing existing git worktree at ${worktreePath}`)
+    } else {
+      const entries = fs.readdirSync(worktreePath)
+      if (entries.length > 0) {
+        throw new Error(
+          `Refusing to recreate takeover worktree at ${worktreePath} because it already contains files that are not a reusable git worktree. Move or remove the existing contents before restarting takeover.`,
+        )
+      }
+      fs.rmSync(worktreePath, { recursive: true, force: true })
+    }
+  }
+
+  if (!fs.existsSync(worktreePath)) {
+    const currentHead = execSync('git rev-parse --verify HEAD', {
+      cwd: profile.path,
+      encoding: 'utf-8',
+    }).trim()
+    execSync(`git worktree add --detach -f "${worktreePath}" ${currentHead}`, {
+      cwd: profile.path,
+      stdio: 'pipe',
+    })
+    createdWorktree = true
+  }
+
+  if (createdWorktree) {
+    console.log(`  [local] Created git worktree at ${worktreePath}`)
+  }
 
   const localRuntimePaths: TakeoverRuntimePaths = {
     projectRoot: worktreePath,


### PR DESCRIPTION
## Changes
- preserve an existing linked takeover worktree so restart does not discard in-flight edits
- refuse to delete populated non-worktree content or a worktree path owned by another repository
- recreate an empty placeholder directory before adding the linked worktree
- cover restart reuse, destructive-reset blocking, empty-directory recreation, foreign-repo rejection, and non-reusable path probes

## Verification
- `pnpm --filter @wanman/cli typecheck`
- `pnpm exec vitest run packages/cli/src/takeover-local.test.ts packages/cli/src/takeover-local.run.test.ts --coverage --coverage.include='packages/cli/src/takeover-local.ts' --coverage.reporter=text-summary --coverage.reporter=json-summary`
- `pnpm exec vitest run packages/cli/src/takeover-local.test.ts packages/cli/src/takeover-local.run.test.ts --coverage --coverage.include='packages/cli/src/takeover-local.ts' --coverage.reporter=lcovonly --coverage.reporter=json-summary`

## Coverage Notes
- targeted restart-guard run: 17 tests passed
- executable changed lines in `packages/cli/src/takeover-local.ts`: 31/31 covered (100%) based on `coverage/lcov.info`