### PR TITLE
fix(cli): fail early on GitHub permission gaps

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,6 +16,24 @@ This walks through a complete first-run of wanman against any git repo on your m
 Optional:
 - A `@sandbank.dev/db9` brain adapter, if you want cross-run memory — see [architecture.md](architecture.md#brain--persistence).
 
+### GitHub permissions for automated PRs
+
+For repositories hosted on GitHub, takeover resolves the authenticated host `gh` token before creating the isolated agent home. The startup preflight and all agents use that exact token. Takeover stops before starting agents if the credential cannot read repository metadata, push branches, create and read pull requests, or read Actions runs.
+
+For classic personal access tokens or OAuth tokens:
+
+- **`repo`** for private repositories, or **`public_repo`** for public repositories.
+- **`workflow`** when agents must add or edit files under `.github/workflows/`.
+
+For fine-grained personal access tokens and GitHub App installation tokens, grant access to the target repository and at least:
+
+- **Contents: write** — push task branches.
+- **Pull requests: write** — create and update PRs.
+- **Actions: read** — inspect CI status.
+- **Workflows: write** when agents must add or edit files under `.github/workflows/`.
+
+The PR-write check uses GitHub's create-PR authorization path with a nonexistent branch as both head and base. The expected validation response proves the token reached the write-protected endpoint, while the invalid same-branch request cannot create a PR.
+
 ## 2. Clone, install, build
 
 ```bash

--- a/packages/cli/src/github-preflight.test.ts
+++ b/packages/cli/src/github-preflight.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import { assertGitHubPreflight, checkGitHubPreflight, parseGitHubRepository } from './github-preflight.js'
+
+describe('parseGitHubRepository', () => {
+  it.each([
+    ['https://github.com/acme/app.git', 'acme/app'],
+    ['git@github.com:acme/app.git', 'acme/app'],
+    ['ssh://git@github.com/acme/app', 'acme/app'],
+  ])('parses %s', (remote, expected) => {
+    expect(parseGitHubRepository(remote)).toBe(expected)
+  })
+
+  it('ignores non-GitHub remotes', () => {
+    expect(parseGitHubRepository('https://gitlab.com/acme/app.git')).toBeUndefined()
+  })
+})
+
+describe('checkGitHubPreflight', () => {
+  it('passes when auth, push, PR, and Actions checks succeed', () => {
+    const run = vi.fn((command: string) => {
+      if (command.includes('.permissions.push')) return 'true'
+      if (command.includes('--method POST')) throw new Error('HTTP 422: Validation Failed')
+      return 'ok'
+    })
+
+    expect(checkGitHubPreflight('https://github.com/acme/app.git', 'agent-token', run)).toEqual({
+      repository: 'acme/app',
+      failures: [],
+    })
+  })
+
+  it('reports missing agent authentication before attempting repository checks', () => {
+    const run = vi.fn(() => 'ok')
+
+    const result = checkGitHubPreflight('git@github.com:acme/app.git', undefined, run)
+    expect(result.failures).toEqual([expect.stringContaining('gh auth login')])
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('reports missing push, PR read/write, and Actions capabilities', () => {
+    const run = vi.fn((command: string) => {
+      if (command.includes('.permissions.push')) return 'false'
+      if (command.startsWith('gh pr list')) throw new Error('forbidden')
+      if (command.includes('--method POST')) throw new Error('HTTP 403: Resource not accessible by integration')
+      if (command.startsWith('gh run list')) throw new Error('forbidden')
+      return 'ok'
+    })
+
+    const result = checkGitHubPreflight('https://github.com/acme/app', 'agent-token', run)
+    expect(result.failures).toEqual([
+      expect.stringContaining('Contents: write'),
+      expect.stringContaining('read pull requests'),
+      expect.stringContaining('Pull requests: write'),
+      expect.stringContaining('Actions: read'),
+    ])
+  })
+
+  it('reports repository metadata failures', () => {
+    const run = vi.fn((command: string) => {
+      if (command.includes('--jq .full_name')) throw new Error('not found')
+      if (command.includes('.permissions.push')) return 'true'
+      if (command.includes('--method POST')) throw new Error('HTTP 422: Validation Failed')
+      return 'ok'
+    })
+
+    expect(checkGitHubPreflight('https://github.com/acme/app', 'agent-token', run).failures)
+      .toEqual([expect.stringContaining('metadata')])
+  })
+})
+
+describe('assertGitHubPreflight', () => {
+  it('prints a clear successful preflight', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const run = vi.fn((command: string) => {
+      if (command.includes('.permissions.push')) return 'true'
+      if (command.includes('--method POST')) throw new Error('HTTP 422: Validation Failed')
+      return 'ok'
+    })
+
+    assertGitHubPreflight('https://github.com/acme/app.git', 'agent-token', run)
+
+    expect(log).toHaveBeenCalledWith('  [local] GitHub preflight passed for acme/app')
+    log.mockRestore()
+  })
+
+  it('fails before startup with concrete remediation', () => {
+    expect(() => assertGitHubPreflight('https://github.com/acme/app.git', undefined))
+      .toThrow(/Agents were not started[\s\S]*Repair the credential permissions/)
+  })
+})

--- a/packages/cli/src/github-preflight.ts
+++ b/packages/cli/src/github-preflight.ts
@@ -1,0 +1,142 @@
+import { execSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+
+export interface GitHubPreflightResult {
+  repository?: string
+  failures: string[]
+}
+
+type CommandRunner = (command: string) => string
+
+function defaultRunner(command: string, token: string): string {
+  return execSync(command, {
+    encoding: 'utf-8',
+    env: { ...process.env, GH_TOKEN: token },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 10_000,
+    shell: '/bin/bash',
+  }).trim()
+}
+
+function errorOutput(error: unknown): string {
+  if (!(error instanceof Error)) return String(error)
+  const stderr = 'stderr' in error ? String(error.stderr) : ''
+  return `${error.message}\n${stderr}`
+}
+
+function isExpectedPullRequestValidationFailure(error: unknown): boolean {
+  const output = errorOutput(error)
+  return /\bHTTP 422\b/i.test(output)
+}
+
+export function parseGitHubRepository(remote?: string): string | undefined {
+  if (!remote) return undefined
+  const match = remote.trim().match(/github\.com[/:]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/i)
+  if (!match) return undefined
+  return `${match[1]}/${match[2]}`
+}
+
+/**
+ * Run non-mutating GitHub checks before takeover agents start.
+ *
+ * The pull-request write check deliberately submits an invalid same-branch
+ * request. A 422 response proves the credential passed endpoint authorization
+ * without creating a pull request.
+ */
+export function checkGitHubPreflight(
+  remote?: string,
+  token?: string,
+  run?: CommandRunner,
+): GitHubPreflightResult {
+  const repository = parseGitHubRepository(remote)
+  if (!repository) return { failures: [] }
+
+  if (!token) {
+    return {
+      repository,
+      failures: [
+        'GitHub authentication is unavailable. Run `gh auth login -h github.com` or export `GH_TOKEN` before takeover.',
+      ],
+    }
+  }
+
+  const runWithToken = (command: string): string => {
+    if (!run) return defaultRunner(command, token)
+    return run(command)
+  }
+
+  try {
+    runWithToken('command -v gh')
+  } catch {
+    return {
+      repository,
+      failures: ['GitHub CLI `gh` is not installed; install it before running takeover against GitHub.'],
+    }
+  }
+
+  const failures: string[] = []
+  try {
+    runWithToken(`gh api repos/${repository} --jq .full_name`)
+  } catch {
+    failures.push(`Cannot read repository metadata for ${repository}; confirm the repository is accessible to the agent credential.`)
+  }
+
+  try {
+    const canPush = runWithToken(`gh api repos/${repository} --jq '.permissions.push // .permissions.admin // false'`)
+    if (canPush !== 'true') {
+      failures.push(`GitHub credential cannot push to ${repository}; grant Contents: write (or equivalent repository write access).`)
+    }
+  } catch {
+    failures.push(`Unable to verify Contents: write capability for ${repository}.`)
+  }
+
+  try {
+    runWithToken(`gh pr list --repo ${repository} --limit 1 --json number`)
+  } catch {
+    failures.push(`Cannot read pull requests for ${repository}; grant Pull requests: read/write.`)
+  }
+
+  // GitHub has no universal read-only endpoint that reports PR-write access for
+  // OAuth, fine-grained PAT, and installation tokens. Exercise the create-PR
+  // authorization path with the same nonexistent branch as both head and base.
+  // GitHub returns 422 after authorization and cannot create a PR from a branch
+  // to itself, so this verifies write access without creating repository state.
+  const missingBranch = `wanman-preflight-${randomUUID()}-missing`
+  try {
+    runWithToken([
+      `gh api --method POST repos/${repository}/pulls`,
+      '-f title=wanman-permission-preflight',
+      `-f head=${missingBranch}`,
+      `-f base=${missingBranch}`,
+    ].join(' '))
+    failures.push(`Pull-request write probe for ${repository} returned an unexpected success; no PR should be creatable from a branch to itself.`)
+  } catch (error) {
+    if (!isExpectedPullRequestValidationFailure(error)) {
+      failures.push(`Cannot create pull requests in ${repository}; grant Pull requests: write.`)
+    }
+  }
+
+  try {
+    runWithToken(`gh run list --repo ${repository} --limit 1 --json databaseId`)
+  } catch {
+    failures.push(`Cannot read GitHub Actions runs for ${repository}; grant Actions: read.`)
+  }
+
+  return { repository, failures }
+}
+
+export function assertGitHubPreflight(remote?: string, token?: string, run?: CommandRunner): void {
+  const result = checkGitHubPreflight(remote, token, run)
+  if (!result.repository) return
+
+  if (result.failures.length === 0) {
+    console.log(`  [local] GitHub preflight passed for ${result.repository}`)
+    return
+  }
+
+  throw new Error([
+    `GitHub preflight failed for ${result.repository}:`,
+    ...result.failures.map(failure => `  - ${failure}`),
+    'Agents were not started. Repair the credential permissions and run takeover again.',
+  ].join('\n'))
+}

--- a/packages/cli/src/local-supervisor.test.ts
+++ b/packages/cli/src/local-supervisor.test.ts
@@ -1,13 +1,14 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { tmpdir } from 'node:os'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   buildLocalSupervisorEnv,
   createHomeLayout,
   createLocalLogBuffer,
   installSharedSkills,
   resolveCliEntrypoint,
+  resolveGitHubToken,
   resolveRuntimeEntrypoint,
   syncHomeEntry,
 } from './local-supervisor.js'
@@ -215,5 +216,33 @@ describe('buildLocalSupervisorEnv', () => {
     expect(env['CODEX_CI']).toBeUndefined()
     expect(env['CODEX_SANDBOX_NETWORK_DISABLED']).toBeUndefined()
     expect(env['CODEX_THREAD_ID']).toBeUndefined()
+  })
+
+  it('passes a resolved GitHub token to isolated agents', () => {
+    const env = buildLocalSupervisorEnv({ PATH: '/usr/bin' }, {
+      configPath: '/tmp/agents.json',
+      workspaceRoot: '/tmp/agents',
+      gitRoot: '/tmp/repo',
+      sharedSkillsDir: '/tmp/skills',
+      homeRoot: '/tmp/home-root',
+    }, '/tmp/home', '/tmp/bin', 3333, 'secret-token')
+
+    expect(env['GH_TOKEN']).toBe('secret-token')
+  })
+})
+
+describe('resolveGitHubToken', () => {
+  it('prefers an explicitly inherited token', () => {
+    const reader = vi.fn(() => 'keyring-token')
+    expect(resolveGitHubToken({ GH_TOKEN: 'env-token' }, reader)).toBe('env-token')
+    expect(reader).not.toHaveBeenCalled()
+  })
+
+  it('reads the host gh keyring before HOME isolation', () => {
+    expect(resolveGitHubToken({ HOME: '/host' }, () => ' keyring-token\n')).toBe('keyring-token')
+  })
+
+  it('continues without GitHub auth when gh is unavailable', () => {
+    expect(resolveGitHubToken({}, () => { throw new Error('missing') })).toBeUndefined()
   })
 })

--- a/packages/cli/src/local-supervisor.ts
+++ b/packages/cli/src/local-supervisor.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs'
 import * as net from 'node:net'
 import * as path from 'node:path'
-import { spawn, type ChildProcess } from 'node:child_process'
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import type { AgentMatrixConfig } from '@wanman/core'
 import type { AgentRuntime } from '@wanman/core'
@@ -19,6 +19,8 @@ export interface LocalSupervisorOptions {
   runtime?: AgentRuntime
   codexModel?: string
   codexReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh'
+  /** Exact GitHub credential already preflighted for takeover agents. */
+  githubToken?: string
   /** @internal test/embedded override; defaults to the built runtime entrypoint. */
   runtimeEntrypoint?: string
   /** @internal test/embedded override; defaults to the current CLI entrypoint. */
@@ -181,6 +183,31 @@ export function createHomeLayout(
   return { agentHome, binDir }
 }
 
+type GitHubTokenReader = (env: NodeJS.ProcessEnv) => string
+
+function readHostGitHubToken(env: NodeJS.ProcessEnv): string {
+  return execFileSync('gh', ['auth', 'token', '-h', 'github.com'], {
+    encoding: 'utf-8',
+    env,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: 5000,
+  }).trim()
+}
+
+/** Resolve GitHub auth before HOME is replaced with the isolated agent home. */
+export function resolveGitHubToken(
+  baseEnv: NodeJS.ProcessEnv,
+  readToken: GitHubTokenReader = readHostGitHubToken,
+): string | undefined {
+  const inherited = baseEnv['GH_TOKEN']?.trim() || baseEnv['GITHUB_TOKEN']?.trim()
+  if (inherited) return inherited
+  try {
+    return readToken(baseEnv).trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
 /** @internal exported for testing */
 export function buildLocalSupervisorEnv(
   baseEnv: NodeJS.ProcessEnv,
@@ -188,6 +215,7 @@ export function buildLocalSupervisorEnv(
   agentHome: string,
   binDir: string,
   port: number,
+  githubToken?: string,
 ): NodeJS.ProcessEnv {
   const env = { ...baseEnv }
 
@@ -206,6 +234,7 @@ export function buildLocalSupervisorEnv(
     WANMAN_SKILLS: opts.workspaceRoot,
     WANMAN_GIT_ROOT: opts.gitRoot,
     WANMAN_SHARED_SKILLS: opts.sharedSkillsDir,
+    ...(githubToken ? { GH_TOKEN: githubToken } : {}),
     ...(opts.goal ? { WANMAN_GOAL: opts.goal } : {}),
     ...(opts.runtime ? { WANMAN_RUNTIME: opts.runtime } : {}),
     ...(opts.codexModel ? { WANMAN_CODEX_MODEL: opts.codexModel } : {}),
@@ -225,11 +254,12 @@ export async function startLocalSupervisor(opts: LocalSupervisorOptions): Promis
   })
   installSharedSkills(opts.sharedSkillsDir, agentHome)
 
+  const githubToken = opts.githubToken ?? resolveGitHubToken(process.env)
   const logBuffer = createLocalLogBuffer()
   const child = spawn('node', [entrypoint], {
     cwd: opts.gitRoot,
     stdio: ['ignore', 'pipe', 'pipe'],
-    env: buildLocalSupervisorEnv(process.env, opts, agentHome, binDir, port),
+    env: buildLocalSupervisorEnv(process.env, opts, agentHome, binDir, port, githubToken),
   })
   child.stdout?.on('data', chunk => logBuffer.pushChunk(chunk))
   child.stderr?.on('data', chunk => logBuffer.pushChunk(chunk))

--- a/packages/cli/src/takeover-local.run.test.ts
+++ b/packages/cli/src/takeover-local.run.test.ts
@@ -9,6 +9,8 @@ import type { GeneratedAgentConfig, ProjectProfile } from './takeover-project.js
 const execSyncMock = vi.hoisted(() => vi.fn())
 const runLocalSupervisorSessionMock = vi.hoisted(() => vi.fn())
 const renderDashboardMock = vi.hoisted(() => vi.fn())
+const resolveGitHubTokenMock = vi.hoisted(() => vi.fn(() => 'agent-token'))
+const assertGitHubPreflightMock = vi.hoisted(() => vi.fn())
 
 vi.mock('node:child_process', () => ({
   execSync: execSyncMock,
@@ -16,6 +18,14 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('./local-supervisor-session.js', () => ({
   runLocalSupervisorSession: runLocalSupervisorSessionMock,
+}))
+
+vi.mock('./local-supervisor.js', () => ({
+  resolveGitHubToken: resolveGitHubTokenMock,
+}))
+
+vi.mock('./github-preflight.js', () => ({
+  assertGitHubPreflight: assertGitHubPreflightMock,
 }))
 
 vi.mock('./tui/dashboard.js', async importOriginal => {
@@ -177,10 +187,43 @@ describe('runLocal', () => {
         gitRoot: worktree,
         runtime: 'codex',
         codexModel: 'gpt-test',
+        githubToken: 'agent-token',
       }),
       keep: false,
       signalMode: 'forward_only',
     }))
+    expect(assertGitHubPreflightMock).toHaveBeenCalledWith(profile.githubRemote, 'agent-token')
     expect(fs.readFileSync(path.join(wanmanDir, 'live-dashboard.txt'), 'utf-8')).toContain('Implement')
+  })
+
+  it('does not start agents when the GitHub preflight fails', async () => {
+    assertGitHubPreflightMock.mockImplementationOnce(() => {
+      throw new Error('GitHub preflight failed: Pull requests: write')
+    })
+
+    const project = makeTmpDir()
+    const wanmanDir = path.join(project, '.wanman')
+    fs.mkdirSync(path.join(wanmanDir, 'worktree'), { recursive: true })
+    fs.mkdirSync(path.join(wanmanDir, 'agents'), { recursive: true })
+    fs.mkdirSync(path.join(wanmanDir, 'skills'), { recursive: true })
+
+    const profile = {
+      path: project,
+      packageManagers: [],
+      githubRemote: 'https://github.com/acme/app.git',
+    } as unknown as ProjectProfile
+
+    await expect(runLocal(profile, { runtime: 'codex', goal: 'Ship', agents: [] } as unknown as GeneratedAgentConfig, wanmanDir, {
+      loops: 1,
+      pollInterval: 0,
+      output: path.join(project, 'out'),
+      keep: false,
+      noBrain: true,
+      infinite: false,
+      errorLimit: 1,
+      runtime: 'codex',
+    })).rejects.toThrow('Pull requests: write')
+
+    expect(runLocalSupervisorSessionMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/takeover-local.ts
+++ b/packages/cli/src/takeover-local.ts
@@ -3,6 +3,8 @@ import * as path from 'node:path'
 import { execSync } from 'node:child_process'
 import logUpdate from 'log-update'
 import type { RunOptions } from './execution-session.js'
+import { assertGitHubPreflight } from './github-preflight.js'
+import { resolveGitHubToken } from './local-supervisor.js'
 import { runLocalSupervisorSession } from './local-supervisor-session.js'
 import {
   createTakeoverCoordinationBackend,
@@ -498,6 +500,8 @@ export async function runLocal(
   const sharedSkillsDir = path.join(wanmanDir, 'skills')
   fs.writeFileSync(liveDashboardPath, 'takeover starting...\n')
   warnLocalEnvironment(profile, worktreePath)
+  const githubToken = profile.githubRemote ? resolveGitHubToken(process.env) : undefined
+  assertGitHubPreflight(profile.githubRemote, githubToken)
 
   console.log('\n  Starting supervisor locally...')
   console.log(`  Config:     ${configPath}`)
@@ -520,6 +524,7 @@ export async function runLocal(
       runtime: generated.runtime,
       codexModel: opts.codexModel,
       codexReasoningEffort: opts.codexReasoningEffort,
+      githubToken,
     },
     keep: opts.keep,
     signalMode: 'forward_only',


### PR DESCRIPTION
## Problem

`wanman takeover` tells dev and CTO agents to push branches, create and review pull requests, and inspect Actions runs. Startup did not verify those GitHub capabilities, and the isolated agent `HOME` could hide the host `gh` keyring credential. Agents therefore discovered missing permissions only after work had started.

The existing repository-role check alone is also insufficient for fine-grained PAT and GitHub App credentials because PR and Actions permissions are independent.

## Fix

Takeover startup now:

1. Detects the GitHub owner/repository from the `origin` remote.
2. Resolves the exact host `gh` token before creating the isolated agent home.
3. Uses that same token for the preflight and passes it to agents as `GH_TOKEN`.
4. Verifies repository metadata access, push capability, PR read/write capability, and Actions visibility.
5. Aborts before starting the supervisor with concrete remediation when any required check fails.

PR-write access is checked without creating repository state: the preflight calls the create-PR endpoint with the same nonexistent branch as head and base. An authorized credential reaches GitHub validation and returns HTTP 422; a credential without Pull requests: write is rejected before validation.

The quickstart now documents minimum permissions for classic PAT/OAuth, fine-grained PAT, and GitHub App installation-token modes.

## Tests

- Added unit coverage for HTTPS/SSH remote parsing, missing authentication, metadata access, push access, PR read/write access, Actions access, and fatal remediation.
- Added takeover integration coverage proving a failed preflight prevents supervisor startup.
- Added token-resolution and isolated-agent propagation coverage.
- Full `@wanman/cli` suite: 34 files, 382 tests passed.
- `pnpm --filter @wanman/cli typecheck` clean.
- `pnpm --filter @wanman/cli build` clean.
- Live non-mutating preflight passed against `biaoxie/wanman`.

Closes #7